### PR TITLE
Add minimal FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg
+*.egg-info/
+*.egg-info
+.DS_Store
+.env
+venv/
+
+# Node
+node_modules/
+
+# Misc
+*.sqlite
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Kopo Forum API
+
+This repository contains a static front‑end and a minimal REST API for the Kopo forum/blog project. The API is built with **FastAPI** and uses **SQLAlchemy** to connect to a PostgreSQL database.
+
+## Requirements
+
+- Python 3.9+
+- PostgreSQL database
+
+Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Set the `DATABASE_URL` environment variable to point to your PostgreSQL instance. Example:
+
+```bash
+export DATABASE_URL=postgresql://user:password@localhost/forumdb
+```
+
+## Running the API
+
+Start the API with `uvicorn`:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+The API will be available at `http://localhost:8000`.
+
+## Endpoints
+
+- `POST /users` – create a new user
+- `GET /users/{id}` – retrieve a user
+- `POST /articles` – create a new article
+- `GET /articles` – list articles
+
+This is only a starting point. More models and endpoints can be added following the same pattern.

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,18 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://user:password@localhost/forumdb')
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,45 @@
+from typing import List
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import Base, engine, get_db
+
+# Create database tables if they don't exist
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Kopo Forum API")
+
+
+@app.post("/users", response_model=schemas.UserOut)
+def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).filter(models.User.username == user.username).first()
+    if db_user:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    db_user = models.User(**user.dict())
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@app.get("/users/{user_id}", response_model=schemas.UserOut)
+def read_user(user_id: int, db: Session = Depends(get_db)):
+    user = db.query(models.User).get(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@app.post("/articles", response_model=schemas.ArticleOut)
+def create_article(article: schemas.ArticleCreate, db: Session = Depends(get_db)):
+    db_article = models.Article(**article.dict())
+    db.add(db_article)
+    db.commit()
+    db.refresh(db_article)
+    return db_article
+
+
+@app.get("/articles", response_model=List[schemas.ArticleOut])
+def read_articles(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return db.query(models.Article).offset(skip).limit(limit).all()

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,33 @@
+from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, func
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(50), unique=True, nullable=False)
+    email = Column(String(255), unique=True, nullable=False)
+    pass_hash = Column(Text, nullable=False)
+    bio = Column(Text)
+    avatar_url = Column(Text)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, server_default=func.now())
+
+    articles = relationship('Article', back_populates='author')
+
+
+class Article(Base):
+    __tablename__ = 'articles'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    title = Column(String(255), nullable=False)
+    content = Column(Text, nullable=False)
+    is_pub = Column(Boolean, default=False)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    author = relationship('User', back_populates='articles')

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class UserBase(BaseModel):
+    username: str
+    email: str
+    bio: Optional[str] = None
+    avatar_url: Optional[str] = None
+
+
+class UserCreate(UserBase):
+    pass_hash: str
+
+
+class UserOut(UserBase):
+    id: int
+    is_active: bool
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class ArticleBase(BaseModel):
+    title: str
+    content: str
+    is_pub: Optional[bool] = False
+
+
+class ArticleCreate(ArticleBase):
+    user_id: Optional[int]
+
+
+class ArticleOut(ArticleBase):
+    id: int
+    user_id: Optional[int]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+SQLAlchemy
+psycopg2-binary
+pydantic


### PR DESCRIPTION
## Summary
- set up `.gitignore`
- document API usage in `README`
- add `requirements.txt` for backend deps
- implement FastAPI backend with SQLAlchemy models

## Testing
- `python3 -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6853d181a8a483328c0afde9e01e9d6c