### PR TITLE
Add script to enable remote access

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ bash setup_db.sh
 ```
 Il crée la base (si nécessaire) et importe `forum.sql`.
 
+## Activer l'accès réseau
+
+Si la base doit être accessible depuis d'autres conteneurs, utilisez le script
+`enable_remote_access.sh`. Il configure `postgresql.conf` et `pg_hba.conf` pour
+autoriser les connexions distantes puis redémarre le service.
+
+Exemple d'usage pour autoriser tout le réseau :
+
+```bash
+sudo bash enable_remote_access.sh
+```
+
+Vous pouvez aussi spécifier un sous-réseau autorisé :
+
+```bash
+sudo bash enable_remote_access.sh 192.168.1.0/24
+```
+
+
 ## Notes
 
 - Adaptez les noms de base ou d'utilisateur selon vos besoins en modifiant le script.

--- a/README.md
+++ b/README.md
@@ -65,5 +65,4 @@ sudo bash enable_remote_access.sh 192.168.1.0/24
 ## Notes
 
 - Adaptez les noms de base ou d'utilisateur selon vos besoins en modifiant le script.
-- Pensez à configurer l'accès réseau de PostgreSQL si l'application se trouve hors du conteneur.
 

--- a/enable_remote_access.sh
+++ b/enable_remote_access.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Configure PostgreSQL to accept remote connections
+# Usage: sudo bash enable_remote_access.sh [SUBNET]
+# SUBNET defaults to 0.0.0.0/0 (toutes adresses)
+set -e
+
+PG_VERSION=$(ls /etc/postgresql | head -n1)
+CONF_DIR="/etc/postgresql/$PG_VERSION/main"
+POSTGRESQL_CONF="$CONF_DIR/postgresql.conf"
+PG_HBA="$CONF_DIR/pg_hba.conf"
+
+SUBNET=${1:-0.0.0.0/0}
+
+# Active l'ecoute sur toutes les interfaces
+sudo sed -i "s/^#*\s*listen_addresses\s*=.*$/listen_addresses = '*'/'" "$POSTGRESQL_CONF"
+
+# Ajoute la ligne d'autorisation si absente
+if ! grep -q "^host\s\+all\s\+all\s\+$SUBNET" "$PG_HBA"; then
+    echo "host    all             all             $SUBNET            md5" | sudo tee -a "$PG_HBA"
+fi
+
+# Redemarre PostgreSQL
+sudo systemctl restart postgresql
+
+echo "Acces distant active pour $SUBNET"
+


### PR DESCRIPTION
## Summary
- add `enable_remote_access.sh` to quickly configure PostgreSQL for remote connections
- document the new script in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853f5163e3c8332b662a9541f317dbe