### PR TITLE
Grant kopo_user table privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ Pour automatiser les étapes 4 à 6, un script `setup_db.sh` est fourni. Exécut
 bash setup_db.sh
 ```
 Le script crée la base (si nécessaire) et importe `forum.sql`. Il crée aussi un
-utilisateur `kopo_user` avec le mot de passe `kopo_pass` (haché via SCRAM).
+utilisateur `kopo_user` avec le mot de passe `kopo_pass` (haché via SCRAM). Ce
+compte reçoit tous les droits sur la base et sur l'ensemble des tables et
+séquences du schéma `public` afin qu'il puisse manipuler les données existantes
+et futures.
 Vous pouvez définir d'autres identifiants via les variables `DB_USER` et
 `DB_PASS` :
 

--- a/setup_db.sh
+++ b/setup_db.sh
@@ -44,5 +44,13 @@ fi
 # Grant privileges on the database
 sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER"
 
+# Grant access to all tables and sequences in the public schema
+sudo -u postgres psql -d "$DB_NAME" -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO $DB_USER"
+sudo -u postgres psql -d "$DB_NAME" -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $DB_USER"
+
+# Ensure future tables/sequences are accessible too
+sudo -u postgres psql -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO $DB_USER"
+sudo -u postgres psql -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO $DB_USER"
+
 sudo systemctl restart postgresql
 


### PR DESCRIPTION
## Summary
- grant table and sequence privileges in `setup_db.sh`
- clarify in README that the initialization script grants access to all tables and sequences

## Testing
- `bash -n setup_db.sh`
- `bash -n enable_remote_access.sh`


------
https://chatgpt.com/codex/tasks/task_e_6854153c34908332838c73c2956a35cc