### PR TITLE
Add forum and comment API features

### DIFF
--- a/api_test.py
+++ b/api_test.py
@@ -39,7 +39,85 @@ def main():
         resp = requests.post(f"{BASE_URL}/articles", json=article_payload)
         print_result("Create article", resp)
 
-    # 4. List articles
+        if resp.ok:
+            article_id = resp.json().get("id")
+
+            # 4. Get single article
+            resp = requests.get(f"{BASE_URL}/articles/{article_id}")
+            print_result("Get article", resp)
+
+            # 5. Add a comment to the article
+            comment_payload = {
+                "post_id": article_id,
+                "user_id": user_id,
+                "content": "Nice post!"
+            }
+            resp = requests.post(f"{BASE_URL}/articles/{article_id}/comments", json=comment_payload)
+            print_result("Create comment", resp)
+
+            # 6. List comments for the article
+            resp = requests.get(f"{BASE_URL}/articles/{article_id}/comments")
+            print_result("List comments", resp)
+
+            # 7. Create a forum category
+            category_payload = {
+                "name": "General",
+                "description": "General discussion"
+            }
+            resp = requests.post(f"{BASE_URL}/forum/categories", json=category_payload)
+            print_result("Create category", resp)
+
+            if resp.ok:
+                category_id = resp.json().get("id")
+
+                # 8. List categories
+                resp = requests.get(f"{BASE_URL}/forum/categories")
+                print_result("List categories", resp)
+
+                # 9. Create a thread
+                thread_payload = {
+                    "title": "Welcome",
+                    "content": "Introduce yourself here",
+                    "user_id": user_id,
+                    "category_id": category_id
+                }
+                resp = requests.post(f"{BASE_URL}/forum/threads", json=thread_payload)
+                print_result("Create thread", resp)
+
+                if resp.ok:
+                    thread_id = resp.json().get("id")
+
+                    # 10. List threads
+                    resp = requests.get(f"{BASE_URL}/forum/threads")
+                    print_result("List threads", resp)
+
+                    # 11. Get single thread
+                    resp = requests.get(f"{BASE_URL}/forum/threads/{thread_id}")
+                    print_result("Get thread", resp)
+
+                    # 12. Add a reply
+                    reply_payload = {
+                        "thread_id": thread_id,
+                        "user_id": user_id,
+                        "content": "Hello everyone"
+                    }
+                    resp = requests.post(f"{BASE_URL}/forum/threads/{thread_id}/replies", json=reply_payload)
+                    print_result("Create reply", resp)
+
+                    # 13. List replies
+                    resp = requests.get(f"{BASE_URL}/forum/threads/{thread_id}/replies")
+                    print_result("List replies", resp)
+
+                    # 14. Like the article
+                    like_payload = {
+                        "user_id": user_id,
+                        "target_type": "article",
+                        "target_id": article_id
+                    }
+                    resp = requests.post(f"{BASE_URL}/likes", json=like_payload)
+                    print_result("Create like", resp)
+
+    # Final: list all articles
     resp = requests.get(f"{BASE_URL}/articles")
     print_result("List articles", resp)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,3 +43,92 @@ def create_article(article: schemas.ArticleCreate, db: Session = Depends(get_db)
 @app.get("/articles", response_model=List[schemas.ArticleOut])
 def read_articles(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
     return db.query(models.Article).offset(skip).limit(limit).all()
+
+
+@app.get("/articles/{article_id}", response_model=schemas.ArticleOut)
+def read_article(article_id: int, db: Session = Depends(get_db)):
+    article = db.query(models.Article).get(article_id)
+    if not article:
+        raise HTTPException(status_code=404, detail="Article not found")
+    return article
+
+
+@app.post("/articles/{article_id}/comments", response_model=schemas.CommentOut)
+def create_comment(article_id: int, comment: schemas.CommentCreate, db: Session = Depends(get_db)):
+    if not db.query(models.Article).get(article_id):
+        raise HTTPException(status_code=404, detail="Article not found")
+    db_comment = models.Comment(post_id=article_id, **comment.dict(exclude={"post_id"}))
+    db.add(db_comment)
+    db.commit()
+    db.refresh(db_comment)
+    return db_comment
+
+
+@app.get("/articles/{article_id}/comments", response_model=List[schemas.CommentOut])
+def list_comments(article_id: int, db: Session = Depends(get_db)):
+    return db.query(models.Comment).filter(models.Comment.post_id == article_id, models.Comment.parent_id == None).all()
+
+
+@app.post("/forum/categories", response_model=schemas.ForumCategoryOut)
+def create_category(category: schemas.ForumCategoryCreate, db: Session = Depends(get_db)):
+    db_cat = models.ForumCategory(**category.dict())
+    db.add(db_cat)
+    db.commit()
+    db.refresh(db_cat)
+    return db_cat
+
+
+@app.get("/forum/categories", response_model=List[schemas.ForumCategoryOut])
+def list_categories(db: Session = Depends(get_db)):
+    return db.query(models.ForumCategory).order_by(models.ForumCategory.order_index).all()
+
+
+@app.post("/forum/threads", response_model=schemas.ForumThreadOut)
+def create_thread(thread: schemas.ForumThreadCreate, db: Session = Depends(get_db)):
+    db_thread = models.ForumThread(**thread.dict())
+    db.add(db_thread)
+    db.commit()
+    db.refresh(db_thread)
+    return db_thread
+
+
+@app.get("/forum/threads", response_model=List[schemas.ForumThreadOut])
+def list_threads(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return db.query(models.ForumThread).offset(skip).limit(limit).all()
+
+
+@app.get("/forum/threads/{thread_id}", response_model=schemas.ForumThreadOut)
+def read_thread(thread_id: int, db: Session = Depends(get_db)):
+    thread = db.query(models.ForumThread).get(thread_id)
+    if not thread:
+        raise HTTPException(status_code=404, detail="Thread not found")
+    return thread
+
+
+@app.post("/forum/threads/{thread_id}/replies", response_model=schemas.ForumReplyOut)
+def create_reply(thread_id: int, reply: schemas.ForumReplyCreate, db: Session = Depends(get_db)):
+    if not db.query(models.ForumThread).get(thread_id):
+        raise HTTPException(status_code=404, detail="Thread not found")
+    db_reply = models.ForumReply(thread_id=thread_id, **reply.dict(exclude={"thread_id"}))
+    db.add(db_reply)
+    db.commit()
+    db.refresh(db_reply)
+    return db_reply
+
+
+@app.get("/forum/threads/{thread_id}/replies", response_model=List[schemas.ForumReplyOut])
+def list_replies(thread_id: int, db: Session = Depends(get_db)):
+    return db.query(models.ForumReply).filter(models.ForumReply.thread_id == thread_id, models.ForumReply.parent_id == None).all()
+
+
+@app.post("/likes", response_model=schemas.LikeOut)
+def create_like(like: schemas.LikeCreate, db: Session = Depends(get_db)):
+    db_like = models.Like(**like.dict())
+    db.add(db_like)
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Like already exists")
+    db.refresh(db_like)
+    return db_like

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, func
+from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, func, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from .database import Base
@@ -17,6 +17,9 @@ class User(Base):
     created_at = Column(DateTime, server_default=func.now())
 
     articles = relationship('Article', back_populates='author')
+    comments = relationship('Comment', back_populates='user')
+    threads = relationship('ForumThread', back_populates='user')
+    replies = relationship('ForumReply', back_populates='user')
 
 
 class Article(Base):
@@ -31,3 +34,79 @@ class Article(Base):
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
 
     author = relationship('User', back_populates='articles')
+    comments = relationship('Comment', back_populates='article')
+
+
+class Comment(Base):
+    __tablename__ = 'comments'
+
+    id = Column(Integer, primary_key=True, index=True)
+    post_id = Column(Integer, ForeignKey('articles.id'))
+    user_id = Column(Integer, ForeignKey('users.id'))
+    content = Column(Text, nullable=False)
+    parent_id = Column(Integer, ForeignKey('comments.id'))
+    created_at = Column(DateTime, server_default=func.now())
+
+    user = relationship('User', back_populates='comments')
+    article = relationship('Article', back_populates='comments')
+    replies = relationship('Comment', backref='parent', remote_side=[id])
+
+
+class ForumCategory(Base):
+    __tablename__ = 'forum_categories'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False)
+    description = Column(Text)
+    order_index = Column(Integer)
+
+    threads = relationship('ForumThread', back_populates='category')
+
+
+class ForumThread(Base):
+    __tablename__ = 'forum_threads'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    category_id = Column(Integer, ForeignKey('forum_categories.id'))
+    title = Column(String(255), nullable=False)
+    content = Column(Text, nullable=False)
+    is_locked = Column(Boolean, default=False)
+    is_pinned = Column(Boolean, default=False)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    user = relationship('User', back_populates='threads')
+    category = relationship('ForumCategory', back_populates='threads')
+    replies = relationship('ForumReply', back_populates='thread')
+
+
+class ForumReply(Base):
+    __tablename__ = 'forum_replies'
+
+    id = Column(Integer, primary_key=True, index=True)
+    thread_id = Column(Integer, ForeignKey('forum_threads.id'))
+    user_id = Column(Integer, ForeignKey('users.id'))
+    content = Column(Text, nullable=False)
+    parent_id = Column(Integer, ForeignKey('forum_replies.id'))
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    user = relationship('User', back_populates='replies')
+    thread = relationship('ForumThread', back_populates='replies')
+    replies = relationship('ForumReply', backref='parent', remote_side=[id])
+
+
+class Like(Base):
+    __tablename__ = 'likes'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    target_type = Column(String(50), nullable=False)
+    target_id = Column(Integer, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'target_type', 'target_id'),
+    )
+
+    user = relationship('User')

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -41,3 +41,100 @@ class ArticleOut(ArticleBase):
 
     class Config:
         orm_mode = True
+
+
+class CommentBase(BaseModel):
+    content: str
+    parent_id: Optional[int] = None
+
+
+class CommentCreate(CommentBase):
+    post_id: int
+    user_id: Optional[int]
+
+
+class CommentOut(CommentBase):
+    id: int
+    post_id: int
+    user_id: Optional[int]
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class ForumCategoryBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+    order_index: Optional[int] = None
+
+
+class ForumCategoryCreate(ForumCategoryBase):
+    pass
+
+
+class ForumCategoryOut(ForumCategoryBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class ForumThreadBase(BaseModel):
+    title: str
+    content: str
+    category_id: Optional[int]
+
+
+class ForumThreadCreate(ForumThreadBase):
+    user_id: Optional[int]
+
+
+class ForumThreadOut(ForumThreadBase):
+    id: int
+    user_id: Optional[int]
+    is_locked: bool
+    is_pinned: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class ForumReplyBase(BaseModel):
+    content: str
+    parent_id: Optional[int] = None
+
+
+class ForumReplyCreate(ForumReplyBase):
+    thread_id: int
+    user_id: Optional[int]
+
+
+class ForumReplyOut(ForumReplyBase):
+    id: int
+    thread_id: int
+    user_id: Optional[int]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class LikeBase(BaseModel):
+    target_type: str
+    target_id: int
+
+
+class LikeCreate(LikeBase):
+    user_id: Optional[int]
+
+
+class LikeOut(LikeBase):
+    id: int
+    user_id: Optional[int]
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- expand ORM models for comments, forum categories, threads, replies and likes
- add corresponding Pydantic schemas
- implement REST endpoints for reading articles, posting comments, managing forum categories/threads/replies, and creating likes
- expand API tests for new endpoints

## Testing
- `python -m py_compile backend/*.py`
- `pip install -q -r requirements.txt`
- `python api_test.py http://localhost:8000` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68541c277e488332b3bcd441f16e0ca9