### PR TITLE
Add file attachment endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,8 @@ The API will be available on port **8000** of the container. Replace
 - `GET /users/{id}` – retrieve a user
 - `POST /articles` – create a new article
 - `GET /articles` – list articles
+- `POST /attachments` – upload a file
+- `GET /attachments/{id}` – fetch an attachment
+- `DELETE /attachments/{id}` – delete an attachment
 
 This is only a starting point. More models and endpoints can be added following the same pattern.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,10 @@
 from typing import List
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, UploadFile, File
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
+import os
+import uuid
+import shutil
 
 from . import models, schemas
 from .database import Base, engine, get_db
@@ -132,3 +136,42 @@ def create_like(like: schemas.LikeCreate, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="Like already exists")
     db.refresh(db_like)
     return db_like
+
+
+@app.post("/attachments", response_model=schemas.AttachmentOut)
+async def upload_attachment(file: UploadFile = File(...), db: Session = Depends(get_db)):
+    upload_dir = "uploads"
+    os.makedirs(upload_dir, exist_ok=True)
+    ext = os.path.splitext(file.filename)[1]
+    unique_name = f"{uuid.uuid4()}{ext}"
+    file_path = os.path.join(upload_dir, unique_name)
+    with open(file_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+
+    db_obj = models.Attachment(filename=file.filename, path=file_path, content_type=file.content_type)
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+@app.get("/attachments/{attachment_id}")
+def get_attachment(attachment_id: int, db: Session = Depends(get_db)):
+    att = db.query(models.Attachment).get(attachment_id)
+    if not att:
+        raise HTTPException(status_code=404, detail="Attachment not found")
+    return FileResponse(att.path, media_type=att.content_type, filename=att.filename)
+
+
+@app.delete("/attachments/{attachment_id}")
+def delete_attachment(attachment_id: int, db: Session = Depends(get_db)):
+    att = db.query(models.Attachment).get(attachment_id)
+    if not att:
+        raise HTTPException(status_code=404, detail="Attachment not found")
+    try:
+        os.remove(att.path)
+    except FileNotFoundError:
+        pass
+    db.delete(att)
+    db.commit()
+    return {"detail": "Attachment deleted"}

--- a/backend/models.py
+++ b/backend/models.py
@@ -110,3 +110,13 @@ class Like(Base):
     )
 
     user = relationship('User')
+
+
+class Attachment(Base):
+    __tablename__ = 'attachments'
+
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String(255), nullable=False)
+    path = Column(String(255), nullable=False)
+    content_type = Column(String(100))
+    created_at = Column(DateTime, server_default=func.now())

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -138,3 +138,13 @@ class LikeOut(LikeBase):
 
     class Config:
         orm_mode = True
+
+
+class AttachmentOut(BaseModel):
+    id: int
+    filename: str
+    content_type: Optional[str] = None
+    created_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- create `Attachment` model and schema for storing file metadata
- implement `/attachments` upload, fetch and delete endpoints
- document new endpoints in README
- keep an `uploads` directory in repository

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68542be6eff48332b7b32340eef0f50a