### PR TITLE
Add direct messaging and notifications

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -132,3 +132,47 @@ def create_like(like: schemas.LikeCreate, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="Like already exists")
     db.refresh(db_like)
     return db_like
+
+
+@app.post("/messages", response_model=schemas.DirectMessageOut)
+def send_message(message: schemas.DirectMessageCreate, db: Session = Depends(get_db)):
+    db_msg = models.DirectMessage(**message.dict())
+    db.add(db_msg)
+    db.commit()
+    db.refresh(db_msg)
+    return db_msg
+
+
+@app.get("/messages/{user_id}", response_model=List[schemas.DirectMessageOut])
+def read_messages(user_id: int, db: Session = Depends(get_db)):
+    msgs = db.query(models.DirectMessage).filter(models.DirectMessage.receiver_id == user_id).all()
+    for msg in msgs:
+        if not msg.is_read:
+            msg.is_read = True
+    db.commit()
+    return msgs
+
+
+@app.post("/notifications", response_model=schemas.NotificationOut)
+def create_notification(notification: schemas.NotificationCreate, db: Session = Depends(get_db)):
+    db_notif = models.Notification(**notification.dict())
+    db.add(db_notif)
+    db.commit()
+    db.refresh(db_notif)
+    return db_notif
+
+
+@app.get("/notifications/{user_id}", response_model=List[schemas.NotificationOut])
+def list_notifications(user_id: int, db: Session = Depends(get_db)):
+    return db.query(models.Notification).filter(models.Notification.user_id == user_id).all()
+
+
+@app.post("/notifications/{notif_id}/read", response_model=schemas.NotificationOut)
+def mark_notification_read(notif_id: int, db: Session = Depends(get_db)):
+    notif = db.query(models.Notification).get(notif_id)
+    if not notif:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    notif.is_read = True
+    db.commit()
+    db.refresh(notif)
+    return notif

--- a/backend/models.py
+++ b/backend/models.py
@@ -110,3 +110,29 @@ class Like(Base):
     )
 
     user = relationship('User')
+
+
+class DirectMessage(Base):
+    __tablename__ = 'direct_messages'
+
+    id = Column(Integer, primary_key=True, index=True)
+    sender_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    receiver_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    content = Column(Text, nullable=False)
+    is_read = Column(Boolean, default=False)
+    created_at = Column(DateTime, server_default=func.now())
+
+    sender = relationship('User', foreign_keys=[sender_id])
+    receiver = relationship('User', foreign_keys=[receiver_id])
+
+
+class Notification(Base):
+    __tablename__ = 'notifications'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    message = Column(Text, nullable=False)
+    is_read = Column(Boolean, default=False)
+    created_at = Column(DateTime, server_default=func.now())
+
+    user = relationship('User')

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -138,3 +138,41 @@ class LikeOut(LikeBase):
 
     class Config:
         orm_mode = True
+
+
+class DirectMessageBase(BaseModel):
+    content: str
+
+
+class DirectMessageCreate(DirectMessageBase):
+    sender_id: Optional[int]
+    receiver_id: int
+
+
+class DirectMessageOut(DirectMessageBase):
+    id: int
+    sender_id: Optional[int]
+    receiver_id: int
+    is_read: bool
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class NotificationBase(BaseModel):
+    message: str
+
+
+class NotificationCreate(NotificationBase):
+    user_id: Optional[int]
+
+
+class NotificationOut(NotificationBase):
+    id: int
+    user_id: Optional[int]
+    is_read: bool
+    created_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add `DirectMessage` and `Notification` ORM models
- expand Pydantic schemas for messages and notifications
- implement endpoints for sending/reading messages
- implement endpoints for listing/marking notifications as read

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68542be3c2fc833291090cbcd493bf8e