### PR TITLE
Add profile and password reset features

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from typing import List
+from uuid import uuid4
 from fastapi import FastAPI, Depends, HTTPException
 from sqlalchemy.orm import Session
 
@@ -29,6 +30,31 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user
+
+
+@app.get("/users/{user_id}/profile", response_model=schemas.UserProfileOut)
+def read_profile(user_id: int, db: Session = Depends(get_db)):
+    profile = db.query(models.UserProfile).filter(models.UserProfile.user_id == user_id).first()
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+
+@app.put("/users/{user_id}/profile", response_model=schemas.UserProfileOut)
+def update_profile(user_id: int, data: schemas.UserProfileUpdate, db: Session = Depends(get_db)):
+    user = db.query(models.User).get(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    profile = db.query(models.UserProfile).filter(models.UserProfile.user_id == user_id).first()
+    if profile:
+        for key, value in data.dict(exclude_unset=True).items():
+            setattr(profile, key, value)
+    else:
+        profile = models.UserProfile(user_id=user_id, **data.dict())
+        db.add(profile)
+    db.commit()
+    db.refresh(profile)
+    return profile
 
 
 @app.post("/articles", response_model=schemas.ArticleOut)
@@ -132,3 +158,29 @@ def create_like(like: schemas.LikeCreate, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="Like already exists")
     db.refresh(db_like)
     return db_like
+
+
+@app.post("/password-reset/request")
+def request_password_reset(data: schemas.PasswordResetRequest, db: Session = Depends(get_db)):
+    user = db.query(models.User).filter(models.User.email == data.email).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    token_str = uuid4().hex
+    token = models.PasswordResetToken(user_id=user.id, token=token_str)
+    db.add(token)
+    db.commit()
+    db.refresh(token)
+    # In real app, send token via email. Here we return it for simplicity.
+    return {"token": token_str}
+
+
+@app.post("/password-reset/confirm")
+def confirm_password_reset(data: schemas.PasswordResetConfirm, db: Session = Depends(get_db)):
+    token = db.query(models.PasswordResetToken).filter(models.PasswordResetToken.token == data.token, models.PasswordResetToken.is_used == False).first()
+    if not token:
+        raise HTTPException(status_code=404, detail="Invalid token")
+    user = token.user
+    user.pass_hash = data.new_pass_hash
+    token.is_used = True
+    db.commit()
+    return {"status": "password updated"}

--- a/backend/models.py
+++ b/backend/models.py
@@ -20,6 +20,8 @@ class User(Base):
     comments = relationship('Comment', back_populates='user')
     threads = relationship('ForumThread', back_populates='user')
     replies = relationship('ForumReply', back_populates='user')
+    profile = relationship('UserProfile', uselist=False, back_populates='user')
+    reset_tokens = relationship('PasswordResetToken', back_populates='user')
 
 
 class Article(Base):
@@ -110,3 +112,28 @@ class Like(Base):
     )
 
     user = relationship('User')
+
+
+class UserProfile(Base):
+    __tablename__ = 'user_profiles'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id'), unique=True)
+    full_name = Column(String(100))
+    website = Column(String(255))
+    location = Column(String(100))
+    about_me = Column(Text)
+
+    user = relationship('User', back_populates='profile')
+
+
+class PasswordResetToken(Base):
+    __tablename__ = 'password_reset_tokens'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    token = Column(String(100), unique=True, nullable=False, index=True)
+    is_used = Column(Boolean, default=False)
+    created_at = Column(DateTime, server_default=func.now())
+
+    user = relationship('User', back_populates='reset_tokens')

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -138,3 +138,31 @@ class LikeOut(LikeBase):
 
     class Config:
         orm_mode = True
+
+
+class UserProfileBase(BaseModel):
+    full_name: Optional[str] = None
+    website: Optional[str] = None
+    location: Optional[str] = None
+    about_me: Optional[str] = None
+
+
+class UserProfileUpdate(UserProfileBase):
+    pass
+
+
+class UserProfileOut(UserProfileBase):
+    id: int
+    user_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class PasswordResetRequest(BaseModel):
+    email: str
+
+
+class PasswordResetConfirm(BaseModel):
+    token: str
+    new_pass_hash: str


### PR DESCRIPTION
## Summary
- add `UserProfile` and `PasswordResetToken` models
- extend pydantic schemas for profiles and password reset
- implement routes to modify profiles and handle password reset workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542bddf764833293b4512643c37c71