### PR TITLE
Add JWT login and hashed password storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This repository contains a static front‑end and a minimal REST API for the Kop
 - Python 3.9+
 - PostgreSQL database
 
-Install Python dependencies:
+Install Python dependencies (includes `passlib` for password hashing and
+`python-jose` for JWT handling):
 
 ```bash
 pip install -r requirements.txt
@@ -34,8 +35,11 @@ The API will be available on port **8000** of the container. Replace
 ## Endpoints
 
 - `POST /users` – create a new user
+  (passwords are hashed server-side)
 - `GET /users/{id}` – retrieve a user
 - `POST /articles` – create a new article
 - `GET /articles` – list articles
+- `POST /login` – obtain a JWT access token
+- `POST /logout` – revoke the current token
 
 This is only a starting point. More models and endpoints can be added following the same pattern.

--- a/api_test.py
+++ b/api_test.py
@@ -19,7 +19,7 @@ def main():
     user_payload = {
         "username": "tester",
         "email": "tester@example.com",
-        "pass_hash": "secret"
+        "password": "secret"
     }
     resp = requests.post(f"{BASE_URL}/users", json=user_payload)
     print_result("Create user", resp)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,9 @@
-from typing import List
+from typing import List, Optional
+from datetime import datetime, timedelta
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
 from . import models, schemas
@@ -10,17 +14,79 @@ Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Kopo Forum API")
 
+# Security configuration
+SECRET_KEY = "secret-key"  # In production use environment variable
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+revoked_tokens: set[str] = set()
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+    if token in revoked_tokens:
+        raise HTTPException(status_code=401, detail="Token revoked")
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: str = payload.get("sub")
+        if user_id is None:
+            raise HTTPException(status_code=401, detail="Invalid token")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    user = db.query(models.User).get(int(user_id))
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
 
 @app.post("/users", response_model=schemas.UserOut)
 def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
     db_user = db.query(models.User).filter(models.User.username == user.username).first()
     if db_user:
         raise HTTPException(status_code=400, detail="Username already registered")
-    db_user = models.User(**user.dict())
+    db_user = models.User(
+        username=user.username,
+        email=user.email,
+        bio=user.bio,
+        avatar_url=user.avatar_url,
+        password_hash=get_password_hash(user.password),
+    )
     db.add(db_user)
     db.commit()
     db.refresh(db_user)
     return db_user
+
+
+@app.post("/login")
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = db.query(models.User).filter(models.User.username == form_data.username).first()
+    if not user or not verify_password(form_data.password, user.password_hash):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    token = create_access_token(data={"sub": str(user.id)}, expires_delta=access_token_expires)
+    return {"access_token": token, "token_type": "bearer"}
+
+
+@app.post("/logout")
+def logout(token: str = Depends(oauth2_scheme)):
+    revoked_tokens.add(token)
+    return {"detail": "Logged out"}
 
 
 @app.get("/users/{user_id}", response_model=schemas.UserOut)

--- a/backend/models.py
+++ b/backend/models.py
@@ -10,7 +10,7 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String(50), unique=True, nullable=False)
     email = Column(String(255), unique=True, nullable=False)
-    pass_hash = Column(Text, nullable=False)
+    password_hash = Column(Text, nullable=False)
     bio = Column(Text)
     avatar_url = Column(Text)
     is_active = Column(Boolean, default=True)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -11,7 +11,7 @@ class UserBase(BaseModel):
 
 
 class UserCreate(UserBase):
-    pass_hash: str
+    password: str
 
 
 class UserOut(UserBase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ SQLAlchemy
 psycopg2-binary
 pydantic
 requests
+passlib[bcrypt]
+python-jose


### PR DESCRIPTION
## Summary
- store user passwords securely using passlib
- implement JWT login/logout endpoints
- test script updated for new password field
- document the new endpoints and dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68542bdcbe3483328586ffcf6bc670dc