### PR TITLE
Add tagging support

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -45,6 +45,14 @@ Ce document fournit une description détaillée de l'API REST proposée dans ce 
 |---------|--------|-----------------------------------|
 | POST    | `/likes` | Ajouter un "j'aime" sur un contenu |
 
+### Tags
+| Méthode | Chemin | Description |
+|---------|-------|-------------|
+| POST    | `/tags` | Créer un tag |
+| GET     | `/tags` | Lister les tags |
+| POST    | `/articles/{id}/tags` | Associer un tag à un article |
+| GET     | `/articles?tag={id}` | Filtrer les articles par tag |
+
 ## Structures de données
 
 Les schémas utilisés par l'API sont définis dans `backend/schemas.py`. Les modèles principaux contiennent les champs suivants (extraits) :

--- a/api_test.py
+++ b/api_test.py
@@ -108,14 +108,31 @@ def main():
                     resp = requests.get(f"{BASE_URL}/forum/threads/{thread_id}/replies")
                     print_result("List replies", resp)
 
-                    # 14. Like the article
-                    like_payload = {
-                        "user_id": user_id,
-                        "target_type": "article",
-                        "target_id": article_id
-                    }
-                    resp = requests.post(f"{BASE_URL}/likes", json=like_payload)
-                    print_result("Create like", resp)
+            # 14. Like the article
+            like_payload = {
+                "user_id": user_id,
+                "target_type": "article",
+                "target_id": article_id
+            }
+            resp = requests.post(f"{BASE_URL}/likes", json=like_payload)
+            print_result("Create like", resp)
+
+            # 15. Create a tag
+            tag_payload = {"name": "news"}
+            resp = requests.post(f"{BASE_URL}/tags", json=tag_payload)
+            print_result("Create tag", resp)
+
+            if resp.ok:
+                tag_id = resp.json().get("id")
+
+                # 16. Assign tag to article
+                assign_payload = {"tag_id": tag_id}
+                resp = requests.post(f"{BASE_URL}/articles/{article_id}/tags", json=assign_payload)
+                print_result("Assign tag", resp)
+
+                # 17. Filter articles by tag
+                resp = requests.get(f"{BASE_URL}/articles", params={"tag": tag_id})
+                print_result("Filter articles", resp)
 
     # Final: list all articles
     resp = requests.get(f"{BASE_URL}/articles")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from fastapi import FastAPI, Depends, HTTPException
 from sqlalchemy.orm import Session
 
@@ -41,8 +41,11 @@ def create_article(article: schemas.ArticleCreate, db: Session = Depends(get_db)
 
 
 @app.get("/articles", response_model=List[schemas.ArticleOut])
-def read_articles(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
-    return db.query(models.Article).offset(skip).limit(limit).all()
+def read_articles(skip: int = 0, limit: int = 10, tag: Optional[int] = None, db: Session = Depends(get_db)):
+    query = db.query(models.Article)
+    if tag is not None:
+        query = query.join(models.ArticleTag).filter(models.ArticleTag.tag_id == tag)
+    return query.offset(skip).limit(limit).all()
 
 
 @app.get("/articles/{article_id}", response_model=schemas.ArticleOut)
@@ -132,3 +135,38 @@ def create_like(like: schemas.LikeCreate, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="Like already exists")
     db.refresh(db_like)
     return db_like
+
+
+@app.post("/tags", response_model=schemas.TagOut)
+def create_tag(tag: schemas.TagCreate, db: Session = Depends(get_db)):
+    db_tag = models.Tag(name=tag.name)
+    db.add(db_tag)
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Tag already exists")
+    db.refresh(db_tag)
+    return db_tag
+
+
+@app.get("/tags", response_model=List[schemas.TagOut])
+def list_tags(db: Session = Depends(get_db)):
+    return db.query(models.Tag).all()
+
+
+@app.post("/articles/{article_id}/tags", response_model=schemas.ArticleTagOut)
+def assign_tag(article_id: int, data: schemas.ArticleTagCreate, db: Session = Depends(get_db)):
+    if not db.query(models.Article).get(article_id):
+        raise HTTPException(status_code=404, detail="Article not found")
+    if not db.query(models.Tag).get(data.tag_id):
+        raise HTTPException(status_code=404, detail="Tag not found")
+    db_at = models.ArticleTag(article_id=article_id, tag_id=data.tag_id)
+    db.add(db_at)
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Tag already assigned")
+    db.refresh(db_at)
+    return db_at

--- a/backend/models.py
+++ b/backend/models.py
@@ -35,6 +35,7 @@ class Article(Base):
 
     author = relationship('User', back_populates='articles')
     comments = relationship('Comment', back_populates='article')
+    article_tags = relationship('ArticleTag', back_populates='article')
 
 
 class Comment(Base):
@@ -110,3 +111,25 @@ class Like(Base):
     )
 
     user = relationship('User')
+
+
+class Tag(Base):
+    __tablename__ = 'tags'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(50), unique=True, nullable=False)
+
+    article_tags = relationship('ArticleTag', back_populates='tag')
+
+
+class ArticleTag(Base):
+    __tablename__ = 'article_tags'
+
+    id = Column(Integer, primary_key=True, index=True)
+    article_id = Column(Integer, ForeignKey('articles.id'))
+    tag_id = Column(Integer, ForeignKey('tags.id'))
+
+    __table_args__ = (UniqueConstraint('article_id', 'tag_id'),)
+
+    article = relationship('Article', back_populates='article_tags')
+    tag = relationship('Tag', back_populates='article_tags')

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -138,3 +138,30 @@ class LikeOut(LikeBase):
 
     class Config:
         orm_mode = True
+
+
+class TagBase(BaseModel):
+    name: str
+
+
+class TagCreate(TagBase):
+    pass
+
+
+class TagOut(TagBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class ArticleTagCreate(BaseModel):
+    tag_id: int
+
+
+class ArticleTagOut(ArticleTagCreate):
+    id: int
+    article_id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add `Tag` and `ArticleTag` ORM models
- include pydantic schemas for tags
- create `/tags` and `/articles/{id}/tags` endpoints
- allow filtering articles by tag
- extend API docs and test script with tag usage

## Testing
- `pip install -r requirements.txt`
- `uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000` with `DATABASE_URL=sqlite:///./test.db`
- `python api_test.py http://localhost:8000`

------
https://chatgpt.com/codex/tasks/task_e_68542be1c3508332ba65389dd4f1aff7