### PR TITLE
Implement moderation endpoints

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -45,6 +45,20 @@ Ce document fournit une description détaillée de l'API REST proposée dans ce 
 |---------|--------|-----------------------------------|
 | POST    | `/likes` | Ajouter un "j'aime" sur un contenu |
 
+### Reports
+| Méthode | Chemin                     | Description                         |
+|---------|---------------------------|-------------------------------------|
+| POST    | `/reports`                | Soumettre un signalement            |
+| GET     | `/reports`                | Lister les signalements (admin)     |
+| PATCH   | `/reports/{id}/resolve`   | Marquer un signalement résolu       |
+
+### Bans
+| Méthode | Chemin        | Description                       |
+|---------|--------------|-----------------------------------|
+| POST    | `/bans`      | Bannir un utilisateur             |
+| GET     | `/bans`      | Lister les bannissements actifs   |
+| DELETE  | `/bans/{id}` | Lever un bannissement             |
+
 ## Structures de données
 
 Les schémas utilisés par l'API sont définis dans `backend/schemas.py`. Les modèles principaux contiennent les champs suivants (extraits) :

--- a/README.md
+++ b/README.md
@@ -37,5 +37,11 @@ The API will be available on port **8000** of the container. Replace
 - `GET /users/{id}` – retrieve a user
 - `POST /articles` – create a new article
 - `GET /articles` – list articles
+- `POST /reports` – submit a report
+- `GET /reports` – list reports (admin)
+- `PATCH /reports/{id}/resolve` – resolve a report
+- `POST /bans` – ban a user
+- `GET /bans` – list active bans
+- `DELETE /bans/{id}` – lift a ban
 
 This is only a starting point. More models and endpoints can be added following the same pattern.

--- a/backend/main.py
+++ b/backend/main.py
@@ -132,3 +132,64 @@ def create_like(like: schemas.LikeCreate, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="Like already exists")
     db.refresh(db_like)
     return db_like
+
+
+@app.post("/reports", response_model=schemas.ReportOut)
+def create_report(report: schemas.ReportCreate, db: Session = Depends(get_db)):
+    db_report = models.Report(**report.dict())
+    db.add(db_report)
+    db.commit()
+    db.refresh(db_report)
+    return db_report
+
+
+@app.get("/reports", response_model=List[schemas.ReportOut])
+def list_reports(db: Session = Depends(get_db)):
+    return db.query(models.Report).all()
+
+
+@app.patch("/reports/{report_id}/resolve", response_model=schemas.ReportOut)
+def resolve_report(report_id: int, db: Session = Depends(get_db)):
+    report = db.query(models.Report).get(report_id)
+    if not report:
+        raise HTTPException(status_code=404, detail="Report not found")
+    report.is_resolved = True
+    log = models.AuditLog(action="resolve_report", target_type="report", target_id=report_id)
+    db.add(log)
+    db.commit()
+    db.refresh(report)
+    return report
+
+
+@app.post("/bans", response_model=schemas.BanOut)
+def create_ban(ban: schemas.BanCreate, db: Session = Depends(get_db)):
+    user = db.query(models.User).get(ban.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.is_active = False
+    db_ban = models.Ban(**ban.dict())
+    db.add(db_ban)
+    db.add(models.AuditLog(action="ban_user", target_type="user", target_id=ban.user_id))
+    db.commit()
+    db.refresh(db_ban)
+    return db_ban
+
+
+@app.get("/bans", response_model=List[schemas.BanOut])
+def list_bans(db: Session = Depends(get_db)):
+    return db.query(models.Ban).filter(models.Ban.is_active == True).all()
+
+
+@app.delete("/bans/{ban_id}", response_model=schemas.BanOut)
+def lift_ban(ban_id: int, db: Session = Depends(get_db)):
+    ban = db.query(models.Ban).get(ban_id)
+    if not ban:
+        raise HTTPException(status_code=404, detail="Ban not found")
+    user = db.query(models.User).get(ban.user_id)
+    if user:
+        user.is_active = True
+    ban.is_active = False
+    db.add(models.AuditLog(action="unban_user", target_type="user", target_id=ban.user_id))
+    db.commit()
+    db.refresh(ban)
+    return ban

--- a/backend/models.py
+++ b/backend/models.py
@@ -110,3 +110,43 @@ class Like(Base):
     )
 
     user = relationship('User')
+
+
+class Report(Base):
+    __tablename__ = 'reports'
+
+    id = Column(Integer, primary_key=True, index=True)
+    reporter_id = Column(Integer, ForeignKey('users.id'))
+    target_type = Column(String(50), nullable=False)
+    target_id = Column(Integer, nullable=False)
+    reason = Column(Text, nullable=False)
+    is_resolved = Column(Boolean, default=False)
+    created_at = Column(DateTime, server_default=func.now())
+
+    reporter = relationship('User')
+
+
+class Ban(Base):
+    __tablename__ = 'bans'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    reason = Column(Text, nullable=False)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, server_default=func.now())
+
+    user = relationship('User')
+
+
+class AuditLog(Base):
+    __tablename__ = 'audit_logs'
+
+    id = Column(Integer, primary_key=True, index=True)
+    action = Column(String(100), nullable=False)
+    performed_by = Column(Integer, ForeignKey('users.id'))
+    target_type = Column(String(50))
+    target_id = Column(Integer)
+    details = Column(Text)
+    created_at = Column(DateTime, server_default=func.now())
+
+    user = relationship('User')

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -138,3 +138,54 @@ class LikeOut(LikeBase):
 
     class Config:
         orm_mode = True
+
+
+class ReportBase(BaseModel):
+    target_type: str
+    target_id: int
+    reason: str
+
+
+class ReportCreate(ReportBase):
+    reporter_id: Optional[int]
+
+
+class ReportOut(ReportBase):
+    id: int
+    reporter_id: Optional[int]
+    is_resolved: bool
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class BanBase(BaseModel):
+    user_id: int
+    reason: str
+
+
+class BanCreate(BanBase):
+    pass
+
+
+class BanOut(BanBase):
+    id: int
+    is_active: bool
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class AuditLogOut(BaseModel):
+    id: int
+    action: str
+    performed_by: Optional[int]
+    target_type: Optional[str] = None
+    target_id: Optional[int] = None
+    details: Optional[str] = None
+    created_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add database models for reports, bans and audit logs
- create report submission and admin endpoints
- implement ban management with audit logging
- document moderation endpoints in README and API guide

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68542be5a8848332b2ab623c79747724