### PR TITLE
Align API models with database schema

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -57,11 +57,11 @@ curl http://localhost:8000/users/1/profile
 ```
 
 ### PUT /users/{id}/profile
-Mettre a jour un profil utilisateur (`full_name`, `website`, `location`, `about_me`).
+Mettre a jour un profil utilisateur (`display_name`, `website`, `location`, `birth_date`, `gender`).
 
 ```bash
 curl -X PUT -H "Content-Type: application/json" \
-     -d '{"full_name":"John Doe"}' \
+    -d '{"display_name":"John"}' \
      http://localhost:8000/users/1/profile
 ```
 
@@ -105,11 +105,11 @@ curl http://localhost:8000/users/1/profile
 ```
 
 ### PUT /users/{id}/profile
-Mettre a jour un profil utilisateur (`full_name`, `website`, `location`, `about_me`).
+Mettre a jour un profil utilisateur (`display_name`, `website`, `location`, `birth_date`, `gender`).
 
 ```bash
 curl -X PUT -H "Content-Type: application/json" \
-     -d '{"full_name":"John Doe"}' \
+    -d '{"display_name":"John"}' \
      http://localhost:8000/users/1/profile
 ```
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -73,7 +73,7 @@ def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
         email=user.email,
         bio=user.bio,
         avatar_url=user.avatar_url,
-        password_hash=get_password_hash(user.password),
+        pass_hash=get_password_hash(user.password),
     )
     db.add(db_user)
     db.commit()
@@ -84,7 +84,7 @@ def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
 @app.post("/login")
 def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
     user = db.query(models.User).filter(models.User.username == form_data.username).first()
-    if not user or not verify_password(form_data.password, user.password_hash):
+    if not user or not verify_password(form_data.password, user.pass_hash):
         raise HTTPException(status_code=401, detail="Invalid credentials")
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     token = create_access_token(data={"sub": str(user.id)}, expires_delta=access_token_expires)
@@ -343,8 +343,8 @@ def resolve_report(report_id: int, db: Session = Depends(get_db)):
     report = db.query(models.Report).get(report_id)
     if not report:
         raise HTTPException(status_code=404, detail="Report not found")
-    report.is_resolved = True
-    log = models.AuditLog(action="resolve_report", target_type="report", target_id=report_id)
+    report.status = "resolved"
+    log = models.AuditLog(actor_id=None, action_type="resolve_report", target_type="report", target_id=report_id)
     db.add(log)
     db.commit()
     db.refresh(report)
@@ -359,7 +359,7 @@ def create_ban(ban: schemas.BanCreate, db: Session = Depends(get_db)):
     user.is_active = False
     db_ban = models.Ban(**ban.dict())
     db.add(db_ban)
-    db.add(models.AuditLog(action="ban_user", target_type="user", target_id=ban.user_id))
+    db.add(models.AuditLog(actor_id=ban.banned_by, action_type="ban_user", target_type="user", target_id=ban.user_id))
     db.commit()
     db.refresh(db_ban)
     return db_ban
@@ -367,7 +367,8 @@ def create_ban(ban: schemas.BanCreate, db: Session = Depends(get_db)):
 
 @app.get("/bans", response_model=List[schemas.BanOut])
 def list_bans(db: Session = Depends(get_db)):
-    return db.query(models.Ban).filter(models.Ban.is_active == True).all()
+    now = datetime.utcnow()
+    return db.query(models.Ban).filter((models.Ban.expires_at == None) | (models.Ban.expires_at > now)).all()
 
 
 @app.delete("/bans/{ban_id}", response_model=schemas.BanOut)
@@ -378,8 +379,8 @@ def lift_ban(ban_id: int, db: Session = Depends(get_db)):
     user = db.query(models.User).get(ban.user_id)
     if user:
         user.is_active = True
-    ban.is_active = False
-    db.add(models.AuditLog(action="unban_user", target_type="user", target_id=ban.user_id))
+    ban.expires_at = datetime.utcnow()
+    db.add(models.AuditLog(actor_id=None, action_type="unban_user", target_type="user", target_id=ban.user_id))
     db.commit()
     db.refresh(ban)
     return ban
@@ -424,7 +425,8 @@ def request_password_reset(data: schemas.PasswordResetRequest, db: Session = Dep
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     token_str = uuid4().hex
-    token = models.PasswordResetToken(user_id=user.id, token=token_str)
+    expires = datetime.utcnow() + timedelta(hours=1)
+    token = models.PasswordResetToken(user_id=user.id, token=token_str, expires_at=expires)
     db.add(token)
     db.commit()
     db.refresh(token)
@@ -434,27 +436,27 @@ def request_password_reset(data: schemas.PasswordResetRequest, db: Session = Dep
 
 @app.post("/password-reset/confirm")
 def confirm_password_reset(data: schemas.PasswordResetConfirm, db: Session = Depends(get_db)):
-    token = db.query(models.PasswordResetToken).filter(models.PasswordResetToken.token == data.token, models.PasswordResetToken.is_used == False).first()
+    token = db.query(models.PasswordResetToken).filter(models.PasswordResetToken.token == data.token, models.PasswordResetToken.used == False).first()
     if not token:
         raise HTTPException(status_code=404, detail="Invalid token")
     user = token.user
     user.pass_hash = data.new_pass_hash
-    token.is_used = True
+    token.used = True
     db.commit()
     return {"status": "password updated"}
   
-@app.post("/messages", response_model=schemas.DirectMessageOut)
-def send_message(message: schemas.DirectMessageCreate, db: Session = Depends(get_db)):
-    db_msg = models.DirectMessage(**message.dict())
+@app.post("/messages", response_model=schemas.MessageOut)
+def send_message(message: schemas.MessageCreate, db: Session = Depends(get_db)):
+    db_msg = models.Message(**message.dict())
     db.add(db_msg)
     db.commit()
     db.refresh(db_msg)
     return db_msg
 
 
-@app.get("/messages/{user_id}", response_model=List[schemas.DirectMessageOut])
+@app.get("/messages/{user_id}", response_model=List[schemas.MessageOut])
 def read_messages(user_id: int, db: Session = Depends(get_db)):
-    msgs = db.query(models.DirectMessage).filter(models.DirectMessage.receiver_id == user_id).all()
+    msgs = db.query(models.Message).filter(models.Message.receiver_id == user_id).all()
     for msg in msgs:
         if not msg.is_read:
             msg.is_read = True
@@ -615,7 +617,8 @@ async def upload_attachment(file: UploadFile = File(...), db: Session = Depends(
     with open(file_path, "wb") as buffer:
         shutil.copyfileobj(file.file, buffer)
 
-    db_obj = models.Attachment(filename=file.filename, path=file_path, content_type=file.content_type)
+    size = os.path.getsize(file_path)
+    db_obj = models.Attachment(file_url=file_path, file_type=file.content_type, file_size=size)
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)
@@ -627,7 +630,7 @@ def get_attachment(attachment_id: int, db: Session = Depends(get_db)):
     att = db.query(models.Attachment).get(attachment_id)
     if not att:
         raise HTTPException(status_code=404, detail="Attachment not found")
-    return FileResponse(att.path, media_type=att.content_type, filename=att.filename)
+    return FileResponse(att.file_url, media_type=att.file_type)
 
 
 @app.delete("/attachments/{attachment_id}")
@@ -636,7 +639,7 @@ def delete_attachment(attachment_id: int, db: Session = Depends(get_db)):
     if not att:
         raise HTTPException(status_code=404, detail="Attachment not found")
     try:
-        os.remove(att.path)
+        os.remove(att.file_url)
     except FileNotFoundError:
         pass
     db.delete(att)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, func, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, Date, ForeignKey, UniqueConstraint, JSON, func
 from sqlalchemy.orm import relationship
 
 from .database import Base
@@ -10,25 +10,91 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String(50), unique=True, nullable=False)
     email = Column(String(255), unique=True, nullable=False)
-    password_hash = Column(Text, nullable=False)
+    pass_hash = Column(Text, nullable=False)
     bio = Column(Text)
     avatar_url = Column(Text)
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, server_default=func.now())
 
+    profile = relationship('UserProfile', uselist=False, back_populates='user')
     articles = relationship('Article', back_populates='author')
     comments = relationship('Comment', back_populates='user')
     threads = relationship('ForumThread', back_populates='user')
     replies = relationship('ForumReply', back_populates='user')
-    profile = relationship('UserProfile', uselist=False, back_populates='user')
     reset_tokens = relationship('PasswordResetToken', back_populates='user')
+    messages_sent = relationship('Message', foreign_keys='Message.sender_id', back_populates='sender')
+    messages_received = relationship('Message', foreign_keys='Message.receiver_id', back_populates='receiver')
+    sessions = relationship('Session', back_populates='user')
+
+
+class UserProfile(Base):
+    __tablename__ = 'user_profiles'
+
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), primary_key=True)
+    display_name = Column(String(100))
+    location = Column(String(100))
+    website = Column(Text)
+    birth_date = Column(Date)
+    gender = Column(String(20))
+    joined_at = Column(DateTime, server_default=func.now())
+
+    user = relationship('User', back_populates='profile')
+
+
+class Role(Base):
+    __tablename__ = 'roles'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(50), unique=True, nullable=False)
+    description = Column(Text)
+
+    user_roles = relationship('UserRole', back_populates='role')
+    role_permissions = relationship('RolePermission', back_populates='role')
+
+
+class Permission(Base):
+    __tablename__ = 'permissions'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), unique=True, nullable=False)
+    description = Column(Text)
+
+    role_permissions = relationship('RolePermission', back_populates='permission')
+
+
+class UserRole(Base):
+    __tablename__ = 'user_roles'
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), primary_key=True)
+    role_id = Column(Integer, ForeignKey('roles.id', ondelete='CASCADE'), primary_key=True)
+
+    user = relationship('User')
+    role = relationship('Role', back_populates='user_roles')
+
+
+class RolePermission(Base):
+    __tablename__ = 'role_permissions'
+    role_id = Column(Integer, ForeignKey('roles.id', ondelete='CASCADE'), primary_key=True)
+    permission_id = Column(Integer, ForeignKey('permissions.id', ondelete='CASCADE'), primary_key=True)
+
+    role = relationship('Role', back_populates='role_permissions')
+    permission = relationship('Permission', back_populates='role_permissions')
+
+
+class Admin(Base):
+    __tablename__ = 'admin'
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(50), unique=True, nullable=False)
+    pass_hash = Column(Text, nullable=False)
+    bio = Column(Text)
+    avatar_url = Column(Text)
 
 
 class Article(Base):
     __tablename__ = 'articles'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'))
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'))
     title = Column(String(255), nullable=False)
     content = Column(Text, nullable=False)
     is_pub = Column(Boolean, default=False)
@@ -40,14 +106,32 @@ class Article(Base):
     article_tags = relationship('ArticleTag', back_populates='article')
 
 
+class Tag(Base):
+    __tablename__ = 'tags'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(50), unique=True, nullable=False)
+
+    article_tags = relationship('ArticleTag', back_populates='tag')
+
+
+class ArticleTag(Base):
+    __tablename__ = 'article_tags'
+    article_id = Column(Integer, ForeignKey('articles.id', ondelete='CASCADE'), primary_key=True)
+    tag_id = Column(Integer, ForeignKey('tags.id', ondelete='CASCADE'), primary_key=True)
+
+    article = relationship('Article', back_populates='article_tags')
+    tag = relationship('Tag', back_populates='article_tags')
+
+
 class Comment(Base):
     __tablename__ = 'comments'
 
     id = Column(Integer, primary_key=True, index=True)
-    post_id = Column(Integer, ForeignKey('articles.id'))
-    user_id = Column(Integer, ForeignKey('users.id'))
+    post_id = Column(Integer, ForeignKey('articles.id', ondelete='CASCADE'))
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'))
     content = Column(Text, nullable=False)
-    parent_id = Column(Integer, ForeignKey('comments.id'))
+    parent_id = Column(Integer, ForeignKey('comments.id', ondelete='CASCADE'))
     created_at = Column(DateTime, server_default=func.now())
 
     user = relationship('User', back_populates='comments')
@@ -70,8 +154,8 @@ class ForumThread(Base):
     __tablename__ = 'forum_threads'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'))
-    category_id = Column(Integer, ForeignKey('forum_categories.id'))
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'))
+    category_id = Column(Integer, ForeignKey('forum_categories.id', ondelete='SET NULL'))
     title = Column(String(255), nullable=False)
     content = Column(Text, nullable=False)
     is_locked = Column(Boolean, default=False)
@@ -88,10 +172,10 @@ class ForumReply(Base):
     __tablename__ = 'forum_replies'
 
     id = Column(Integer, primary_key=True, index=True)
-    thread_id = Column(Integer, ForeignKey('forum_threads.id'))
-    user_id = Column(Integer, ForeignKey('users.id'))
+    thread_id = Column(Integer, ForeignKey('forum_threads.id', ondelete='CASCADE'))
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'))
     content = Column(Text, nullable=False)
-    parent_id = Column(Integer, ForeignKey('forum_replies.id'))
+    parent_id = Column(Integer, ForeignKey('forum_replies.id', ondelete='CASCADE'))
     created_at = Column(DateTime, server_default=func.now())
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
 
@@ -104,7 +188,7 @@ class Like(Base):
     __tablename__ = 'likes'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
     target_type = Column(String(50), nullable=False)
     target_id = Column(Integer, nullable=False)
 
@@ -115,96 +199,12 @@ class Like(Base):
     user = relationship('User')
 
 
-class Report(Base):
-    __tablename__ = 'reports'
+class Message(Base):
+    __tablename__ = 'messages'
 
     id = Column(Integer, primary_key=True, index=True)
-    reporter_id = Column(Integer, ForeignKey('users.id'))
-    target_type = Column(String(50), nullable=False)
-    target_id = Column(Integer, nullable=False)
-    reason = Column(Text, nullable=False)
-    is_resolved = Column(Boolean, default=False)
-    created_at = Column(DateTime, server_default=func.now())
-
-    reporter = relationship('User')
-
-
-class Ban(Base):
-    __tablename__ = 'bans'
-
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
-    reason = Column(Text, nullable=False)
-    is_active = Column(Boolean, default=True)
-    created_at = Column(DateTime, server_default=func.now())
-
-    user = relationship('User')
-
-
-class AuditLog(Base):
-    __tablename__ = 'audit_logs'
-
-    id = Column(Integer, primary_key=True, index=True)
-    action = Column(String(100), nullable=False)
-    performed_by = Column(Integer, ForeignKey('users.id'))
-    target_type = Column(String(50))
-    target_id = Column(Integer)
-    details = Column(Text)
-    created_at = Column(DateTime, server_default=func.now())
-
-    user = relationship('User')
-    
-class Tag(Base):
-    __tablename__ = 'tags'
-
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(50), unique=True, nullable=False)
-
-    article_tags = relationship('ArticleTag', back_populates='tag')
-
-
-class ArticleTag(Base):
-    __tablename__ = 'article_tags'
-
-    id = Column(Integer, primary_key=True, index=True)
-    article_id = Column(Integer, ForeignKey('articles.id'))
-    tag_id = Column(Integer, ForeignKey('tags.id'))
-
-    __table_args__ = (UniqueConstraint('article_id', 'tag_id'),)
-
-    article = relationship('Article', back_populates='article_tags')
-    tag = relationship('Tag', back_populates='article_tags')
-    
-class UserProfile(Base):
-    __tablename__ = 'user_profiles'
-
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), unique=True)
-    full_name = Column(String(100))
-    website = Column(String(255))
-    location = Column(String(100))
-    about_me = Column(Text)
-
-    user = relationship('User', back_populates='profile')
-
-
-class PasswordResetToken(Base):
-    __tablename__ = 'password_reset_tokens'
-
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
-    token = Column(String(100), unique=True, nullable=False, index=True)
-    is_used = Column(Boolean, default=False)
-    created_at = Column(DateTime, server_default=func.now())
-
-    user = relationship('User', back_populates='reset_tokens')
-    
-class DirectMessage(Base):
-    __tablename__ = 'direct_messages'
-
-    id = Column(Integer, primary_key=True, index=True)
-    sender_id = Column(Integer, ForeignKey('users.id'), nullable=False)
-    receiver_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    sender_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
+    receiver_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
     content = Column(Text, nullable=False)
     is_read = Column(Boolean, default=False)
     created_at = Column(DateTime, server_default=func.now())
@@ -212,67 +212,116 @@ class DirectMessage(Base):
     sender = relationship('User', foreign_keys=[sender_id])
     receiver = relationship('User', foreign_keys=[receiver_id])
 
+
+class Report(Base):
+    __tablename__ = 'reports'
+
+    id = Column(Integer, primary_key=True, index=True)
+    reporter_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'))
+    target_type = Column(String(50), nullable=False)
+    target_id = Column(Integer, nullable=False)
+    reason = Column(Text, nullable=False)
+    status = Column(String(20), default='en attente')
+    created_at = Column(DateTime, server_default=func.now())
+
+    reporter = relationship('User')
+
+
 class Notification(Base):
     __tablename__ = 'notifications'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
-    message = Column(Text, nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
+    type = Column(String(50))
+    message = Column(Text)
     is_read = Column(Boolean, default=False)
     created_at = Column(DateTime, server_default=func.now())
+
     user = relationship('User')
-    
-class Attachment(Base):
-    __tablename__ = 'attachments'
-    
+
+
+class Ban(Base):
+    __tablename__ = 'bans'
+
     id = Column(Integer, primary_key=True, index=True)
-    filename = Column(String(255), nullable=False)
-    path = Column(String(255), nullable=False)
-    content_type = Column(String(100))
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
+    reason = Column(Text, nullable=False)
+    banned_by = Column(Integer, ForeignKey('admin.id'))
+    expires_at = Column(DateTime)
     created_at = Column(DateTime, server_default=func.now())
 
+    user = relationship('User')
 
-class Role(Base):
-    __tablename__ = 'roles'
+
+class PasswordResetToken(Base):
+    __tablename__ = 'password_reset_tokens'
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(50), unique=True, nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
+    token = Column(String(255), unique=True, nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    used = Column(Boolean, default=False)
+    created_at = Column(DateTime, server_default=func.now())
+
+    user = relationship('User', back_populates='reset_tokens')
+
+
+class Attachment(Base):
+    __tablename__ = 'attachments'
+
+    id = Column(Integer, primary_key=True, index=True)
+    uploaded_by = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'))
+    file_url = Column(Text, nullable=False)
+    file_type = Column(String(100))
+    file_size = Column(Integer)
+    attached_to_type = Column(String(50))
+    attached_to_id = Column(Integer)
+    uploaded_at = Column(DateTime, server_default=func.now())
+
+
+class Session(Base):
+    __tablename__ = 'sessions'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
+    session_token = Column(String(255), unique=True, nullable=False)
+    ip_address = Column(String(45))
+    user_agent = Column(Text)
+    created_at = Column(DateTime, server_default=func.now())
+    expires_at = Column(DateTime)
+
+    user = relationship('User', back_populates='sessions')
+
+
+class AuditLog(Base):
+    __tablename__ = 'audit_logs'
+
+    id = Column(Integer, primary_key=True, index=True)
+    actor_id = Column(Integer, ForeignKey('users.id'))
+    action_type = Column(String(100))
+    target_type = Column(String(50))
+    target_id = Column(Integer)
     description = Column(Text)
-    user_roles = relationship('UserRole', back_populates='role')
-    role_permissions = relationship('RolePermission', back_populates='role')
+    created_at = Column(DateTime, server_default=func.now())
+
+    actor = relationship('User')
 
 
-class Permission(Base):
-    __tablename__ = 'permissions'
-
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(50), unique=True, nullable=False)
-    description = Column(Text)
-    role_permissions = relationship('RolePermission', back_populates='permission')
-
-
-class UserRole(Base):
-    __tablename__ = 'user_roles'
+class ActivityLog(Base):
+    __tablename__ = 'activity_logs'
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'))
-    role_id = Column(Integer, ForeignKey('roles.id'))
-
-    __table_args__ = (UniqueConstraint('user_id', 'role_id'),)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'))
+    action = Column(String(100))
+    metadata = Column(JSON)
+    created_at = Column(DateTime, server_default=func.now())
 
     user = relationship('User')
-    role = relationship('Role', back_populates='user_roles')
 
 
-class RolePermission(Base):
-    __tablename__ = 'role_permissions'
+class Setting(Base):
+    __tablename__ = 'settings'
 
-    id = Column(Integer, primary_key=True, index=True)
-    role_id = Column(Integer, ForeignKey('roles.id'))
-    permission_id = Column(Integer, ForeignKey('permissions.id'))
-
-    __table_args__ = (UniqueConstraint('role_id', 'permission_id'),)
-
-    role = relationship('Role', back_populates='role_permissions')
-    permission = relationship('Permission', back_populates='role_permissions')
-    
+    key = Column(String(100), primary_key=True)
+    value = Column(Text)
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 from typing import Optional
 from pydantic import BaseModel
 
@@ -183,7 +183,7 @@ class ReportCreate(ReportBase):
 class ReportOut(ReportBase):
     id: int
     reporter_id: Optional[int]
-    is_resolved: bool
+    status: str
     created_at: datetime
 
     class Config:
@@ -193,6 +193,8 @@ class ReportOut(ReportBase):
 class BanBase(BaseModel):
     user_id: int
     reason: str
+    banned_by: Optional[int] = None
+    expires_at: Optional[datetime] = None
 
 
 class BanCreate(BanBase):
@@ -201,8 +203,8 @@ class BanCreate(BanBase):
 
 class BanOut(BanBase):
     id: int
-    is_active: bool
-      
+    created_at: datetime
+
 
 class TagBase(BaseModel):
     name: str
@@ -214,12 +216,14 @@ class TagCreate(TagBase):
 
 class TagOut(TagBase):
     id: int
-        
+
+
 class UserProfileBase(BaseModel):
-    full_name: Optional[str] = None
-    website: Optional[str] = None
+    display_name: Optional[str] = None
     location: Optional[str] = None
-    about_me: Optional[str] = None
+    website: Optional[str] = None
+    birth_date: Optional[date] = None
+    gender: Optional[str] = None
 
 
 class UserProfileUpdate(UserProfileBase):
@@ -227,19 +231,20 @@ class UserProfileUpdate(UserProfileBase):
 
 
 class UserProfileOut(UserProfileBase):
-    id: int
     user_id: int
-      
-class DirectMessageBase(BaseModel):
+    joined_at: datetime
+
+
+class MessageBase(BaseModel):
     content: str
 
 
-class DirectMessageCreate(DirectMessageBase):
+class MessageCreate(MessageBase):
     sender_id: Optional[int]
     receiver_id: int
 
 
-class DirectMessageOut(DirectMessageBase):
+class MessageOut(MessageBase):
     id: int
     sender_id: Optional[int]
     receiver_id: int
@@ -252,22 +257,22 @@ class DirectMessageOut(DirectMessageBase):
 
 class AuditLogOut(BaseModel):
     id: int
-    action: str
-    performed_by: Optional[int]
+    actor_id: Optional[int]
+    action_type: Optional[str] = None
     target_type: Optional[str] = None
     target_id: Optional[int] = None
-    details: Optional[str] = None
-      
-      
+    description: Optional[str] = None
+    created_at: datetime
+
+
 class ArticleTagCreate(BaseModel):
     tag_id: int
 
 
 class ArticleTagOut(ArticleTagCreate):
-    id: int
     article_id: int
-      
-      
+
+
 class PasswordResetRequest(BaseModel):
     email: str
 
@@ -275,9 +280,11 @@ class PasswordResetRequest(BaseModel):
 class PasswordResetConfirm(BaseModel):
     token: str
     new_pass_hash: str
-      
+
+
 class NotificationBase(BaseModel):
-    message: str
+    type: Optional[str] = None
+    message: Optional[str] = None
 
 
 class NotificationCreate(NotificationBase):
@@ -288,12 +295,14 @@ class NotificationOut(NotificationBase):
     id: int
     user_id: Optional[int]
     is_read: bool
-      
+
+
 class AttachmentOut(BaseModel):
     id: int
-    filename: str
-    content_type: Optional[str] = None
-    created_at: datetime
+    file_url: str
+    file_type: Optional[str] = None
+    file_size: Optional[int] = None
+    uploaded_at: datetime
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- update SQLAlchemy models to match provided database schema
- adjust pydantic schemas to new field names
- update API endpoints for renamed fields and new models
- update profile fields in API guide

## Testing
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685434fe8d648332bf0d5234460e617c