### PR TITLE
Fix Unicode errors and bcrypt issue

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -4,7 +4,10 @@ from sqlalchemy.orm import declarative_base, sessionmaker
 
 DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://user:password@localhost/forumdb')
 
-engine = create_engine(DATABASE_URL)
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"client_encoding": "utf8"},
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ psycopg2-binary
 pydantic
 requests
 passlib[bcrypt]
+bcrypt<4
 python-jose


### PR DESCRIPTION
## Summary
- ensure postgres client uses UTF-8 to avoid UnicodeEncodeError
- pin bcrypt below version 4.0 for passlib compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d32711ab08332b1e4b9691e4a41db