### PR TITLE
Improve PHP error handling

### DIFF
--- a/error.php
+++ b/error.php
@@ -1,0 +1,22 @@
+<?php
+// Generic error page
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Erreur</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="/assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="/css/site.css">
+</head>
+<body>
+    <header class="site-header">
+        <h1><a href="/">Kopo Forum</a></h1>
+    </header>
+    <main>
+        <p>Une erreur est survenue. Merci de réessayer plus tard.</p>
+    </main>
+    <footer class="site-footer">&copy; 2025 Kopo</footer>
+</body>
+</html>

--- a/session.php
+++ b/session.php
@@ -24,4 +24,26 @@ function generate_csrf_token() {
 function verify_csrf_token($token) {
     return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
 }
+
+function handle_error($severity, $message, $file, $line) {
+    error_log("PHP error: $message in $file on line $line");
+    http_response_code(500);
+    include __DIR__ . '/error.php';
+    exit;
+}
+
+function handle_exception($exception) {
+    error_log('Uncaught exception: ' . $exception->getMessage());
+    http_response_code(500);
+    include __DIR__ . '/error.php';
+    exit;
+}
+
+function setup_error_handling() {
+    ini_set('display_errors', '0');
+    set_error_handler('handle_error');
+    set_exception_handler('handle_exception');
+}
+
+setup_error_handling();
 ?>

--- a/utils.php
+++ b/utils.php
@@ -27,8 +27,22 @@ function api_request($method, $endpoint, $data = null, $token = null) {
     }
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
     $response = curl_exec($ch);
+    if ($response === false) {
+        error_log('cURL error: ' . curl_error($ch));
+        curl_close($ch);
+        return null;
+    }
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
-    return $response ? json_decode($response, true) : null;
+    if ($status >= 400) {
+        error_log("API request failed with status $status");
+        return null;
+    }
+    $decoded = json_decode($response, true);
+    if ($decoded === null) {
+        error_log('Invalid JSON response from API');
+    }
+    return $decoded;
 }
 
 function fetch_json($endpoint, $params = [], $token = null) {


### PR DESCRIPTION
## Summary
- add global error handling and exception handling
- log API request errors
- show a generic error page for any failure

## Testing
- `for f in *.php; do echo "Checking $f"; php -l $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_685d430feea88332ba9bde17c1e281ff