### PR TITLE
Improve API error handling

### DIFF
--- a/api.php
+++ b/api.php
@@ -55,7 +55,25 @@ class API {
         $result = json_decode($response, true);
         if ($status >= 400) {
             // Handle error based on status code
-            $error_message = isset($result['detail']) ? $result['detail'] : 'API request failed';
+            $error_message = 'API request failed';
+            if (isset($result['detail'])) {
+                $detail = $result['detail'];
+                if (is_array($detail)) {
+                    // FastAPI style validation errors or array messages
+                    $msgs = [];
+                    foreach ($detail as $d) {
+                        if (is_array($d) && isset($d['msg'])) {
+                            $msgs[] = $d['msg'];
+                        } else {
+                            $msgs[] = is_string($d) ? $d : json_encode($d);
+                        }
+                    }
+                    $error_message = implode('; ', $msgs);
+                } else {
+                    $error_message = $detail;
+                }
+            }
+
             throw new Exception('API Error (' . $status . '): ' . $error_message);
         }
         


### PR DESCRIPTION
## Summary
- improve API error parsing to surface messages from the backend

## Testing
- `php -l api.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d63b5d0c48332896f5ce969ea7448