### PR TITLE
Fix login API request

### DIFF
--- a/api.php
+++ b/api.php
@@ -19,7 +19,7 @@ class API {
      * @param bool $auth Whether to include auth token
      * @return array Response data
      */
-    public function request($endpoint, $method = 'GET', $data = [], $auth = false) {
+    public function request($endpoint, $method = 'GET', $data = [], $auth = false, $json = true) {
         $url = $this->base_url . $endpoint;
         $ch = curl_init();
         
@@ -29,7 +29,7 @@ class API {
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
         
         // Headers
-        $headers = ['Content-Type: application/json'];
+        $headers = [$json ? 'Content-Type: application/json' : 'Content-Type: application/x-www-form-urlencoded'];
         if ($auth && $this->token) {
             $headers[] = 'Authorization: Bearer ' . $this->token;
         }
@@ -37,7 +37,11 @@ class API {
         
         // Post data if needed
         if (!empty($data) && $method !== 'GET') {
-            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+            if ($json) {
+                curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+            } else {
+                curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+            }
         }
         
         // Execute request
@@ -88,10 +92,17 @@ class API {
      * @return array User data
      */
     public function login($username, $password) {
-        $response = $this->request('/login', 'POST', [
-            'username' => $username,
-            'password' => $password
-        ]);
+        // The login endpoint expects form-encoded data
+        $response = $this->request(
+            '/login',
+            'POST',
+            [
+                'username' => $username,
+                'password' => $password
+            ],
+            false,
+            false
+        );
         
         if (isset($response['access_token'])) {
             $_SESSION['token'] = $response['access_token'];


### PR DESCRIPTION
## Summary
- fix wrong request format for login
- support either JSON or form encoded data in API client

## Testing
- `php -l api.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d68a9e6908332ba649c1642b87f01