### PR TITLE
Add deploy-api workflow

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,20 @@
+name: Déploiement de la mise a jour API
+
+on:
+  push:
+    branches:
+      - API
+
+jobs:
+  deploy:
+    name: Déploiement webhook sur Proxmox
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Vérification du repo
+        uses: actions/checkout@v4
+
+      - name: Appel webhook Proxmox
+        run: |
+          curl -X POST https://kopo.systems/deploy-api \
+               -H "X-Auth-Token: ${{ secrets.WEBHOOK_TOKEN_FRONT }}"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow `deploy-api` to trigger a Proxmox webhook when pushing to the `API` branch

## Testing
- `python3 -m py_compile api_test.py`


------
https://chatgpt.com/codex/tasks/task_e_686d0b6aa17c8332ad54e5d6479c0360