### PR TITLE
Fix header rendering in controller views

### DIFF
--- a/views/templates/header.php
+++ b/views/templates/header.php
@@ -1,6 +1,8 @@
 <?php
 require_once 'config.php';
 require_once 'api.php';
+// Access the API instance when included from controllers
+global $api;
 ?>
 <!DOCTYPE html>
 <html lang="fr">


### PR DESCRIPTION
## Summary
- ensure `$api` instance is available in header when included from controller context

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f64d9affc8332aaa588dde321c89e