### PR TITLE
Add article count endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The API will be available on port **8000** of the container. Replace
 - `POST /logout` – revoke the current token
 - `POST /articles` – create an article *(requires token)*
 - `GET /articles` – list articles
+- `GET /articles/count` – total number of articles
 - `GET /articles/{id}` – read a single article
 - `PUT/PATCH /articles/{id}` – modify an article *(requires token)*
 - `DELETE /articles/{id}` – delete an article *(requires token)*

--- a/backend/main.py
+++ b/backend/main.py
@@ -151,6 +151,12 @@ def read_articles(skip: int = 0, limit: int = 10, db: Session = Depends(get_db))
     return db.query(models.Article).offset(skip).limit(limit).all()
 
 
+@app.get("/articles/count", response_model=schemas.CountOut)
+def count_articles(db: Session = Depends(get_db)):
+    """Return the total number of articles."""
+    return {"count": db.query(models.Article).count()}
+
+
 @app.get("/articles/{article_id}", response_model=schemas.ArticleOut)
 def read_article(article_id: int, db: Session = Depends(get_db)):
     article = db.query(models.Article).get(article_id)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -50,6 +50,11 @@ class ArticleOut(ArticleBase):
         orm_mode = True
 
 
+class CountOut(BaseModel):
+    """Simple count response schema."""
+    count: int
+
+
 class CommentBase(BaseModel):
     content: str
     parent_id: Optional[int] = None


### PR DESCRIPTION
## Summary
- implement `/articles/count` route
- expose article count schema
- document article count endpoint

## Testing
- `pip install -q -r requirements.txt`
- `python api_test.py http://localhost:8000` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_686f6c799c188332a7ef7cae9b41cf49