### PR TITLE
Remove messaging and follow features

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -440,27 +440,6 @@ Corps JSON :
 curl -X POST -H "Content-Type: application/json" -d '{"token":"<TOKEN>","new_pass_hash":"<HASH>"}' http://localhost:8000/password-reset/confirm
 ```
 
-## Messagerie
-
-### POST /messages
-Envoyer un message direct.
-
-Corps JSON :
-- `sender_id` (optionnel)
-- `receiver_id`
-- `content`
-
-```bash
-curl -X POST -H "Content-Type: application/json" -d '{"receiver_id":2,"content":"Bonjour"}' http://localhost:8000/messages
-```
-
-### GET /messages/{user_id}
-Recuperer les messages pour un utilisateur.
-
-```bash
-curl http://localhost:8000/messages/2
-```
-
 ## Notifications
 
 ### POST /notifications

--- a/membres.php
+++ b/membres.php
@@ -141,37 +141,7 @@ try {
                                 </div>
                             </div>
                             
-                            <?php if ($api->isLoggedIn() && $_SESSION['user']['id'] !== $member['id']): ?>
-                                <div class="member-actions" style="display: flex; gap: 0.5rem;">
-                                    <a href="messages.php?to=<?php echo $member['id']; ?>" class="btn btn-sm btn-outline" style="flex: 1;">
-                                        <i class="far fa-envelope"></i> Message
-                                    </a>
-                                    
-                                    <?php
-                                    $is_following = false;
-                                    try {
-                                        $follow_status = $api->request('/users/' . $_SESSION['user']['id'] . '/following/' . $member['id'], 'GET', [], true);
-                                        $is_following = $follow_status['is_following'] ?? false;
-                                    } catch (Exception $e) {
-                                        // Silently fail if we can't get follow status
-                                    }
-                                    ?>
-                                    
-                                    <form method="post" action="follow.php" style="flex: 1;">
-                                        <input type="hidden" name="user_id" value="<?php echo $member['id']; ?>">
-                                        <input type="hidden" name="action" value="<?php echo $is_following ? 'unfollow' : 'follow'; ?>">
-                                        <input type="hidden" name="redirect" value="membres.php<?php echo !empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : ''; ?>">
-                                        
-                                        <button type="submit" class="btn btn-sm <?php echo $is_following ? 'btn-outline' : 'btn-primary'; ?>" style="width: 100%;">
-                                            <?php if ($is_following): ?>
-                                                <i class="fas fa-user-minus"></i> Abonné
-                                            <?php else: ?>
-                                                <i class="fas fa-user-plus"></i> Suivre
-                                            <?php endif; ?>
-                                        </button>
-                                    </form>
-                                </div>
-                            <?php elseif ($api->isLoggedIn() && $_SESSION['user']['id'] === $member['id']): ?>
+                            <?php if ($api->isLoggedIn() && $_SESSION['user']['id'] === $member['id']): ?>
                                 <div class="member-actions">
                                     <a href="profile.php?id=<?php echo $member['id']; ?>" class="btn btn-sm btn-outline" style="width: 100%;">
                                         <i class="fas fa-user-edit"></i> C'est vous

--- a/profile.php
+++ b/profile.php
@@ -49,33 +49,6 @@ try {
 
 
 
-// Handle following/unfollowing
-$follow_error = '';
-$is_following = false;
-
-if ($api->isLoggedIn() && $user_id != $_SESSION['user']['id']) {
-    try {
-        $follow_status = $api->request('/users/' . $_SESSION['user']['id'] . '/following/' . $user_id, 'GET', [], true);
-        $is_following = $follow_status['is_following'] ?? false;
-    } catch (Exception $e) {
-        // Silently fail if we can't get follow status
-    }
-    
-    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['follow_action'])) {
-        $action = sanitize_string($_POST['follow_action']);
-        try {
-            if ($action === 'follow') {
-                $api->request('/users/' . $_SESSION['user']['id'] . '/following', 'POST', ['following_id' => $user_id], true);
-                $is_following = true;
-            } elseif ($action === 'unfollow') {
-                $api->request('/users/' . $_SESSION['user']['id'] . '/following/' . $user_id, 'DELETE', [], true);
-                $is_following = false;
-            }
-        } catch (Exception $e) {
-            $follow_error = $e->getMessage();
-        }
-    }
-}
 
 include 'header.php';
 ?>
@@ -146,26 +119,6 @@ include 'header.php';
                                 <a href="edit-profile.php" class="btn btn-outline">
                                     <i class="fas fa-cog"></i> Modifier le profil
                                 </a>
-                            <?php elseif ($api->isLoggedIn()): ?>
-                                <div style="display: flex; flex-direction: column; gap: 0.5rem;">
-                                    <form method="post">
-                                        <?php if ($is_following): ?>
-                                            <input type="hidden" name="follow_action" value="unfollow">
-                                            <button type="submit" class="btn btn-outline">
-                                                <i class="fas fa-user-minus"></i> Ne plus suivre
-                                            </button>
-                                        <?php else: ?>
-                                            <input type="hidden" name="follow_action" value="follow">
-                                            <button type="submit" class="btn btn-primary">
-                                                <i class="fas fa-user-plus"></i> Suivre
-                                            </button>
-                                        <?php endif; ?>
-                                    </form>
-                                    
-                                    <a href="messages.php?to=<?php echo $user_id; ?>" class="btn btn-outline">
-                                        <i class="far fa-envelope"></i> Message
-                                    </a>
-                                </div>
                             <?php endif; ?>
                         </div>
                     </div>
@@ -183,10 +136,6 @@ include 'header.php';
                         <div style="flex: 1; text-align: center; border-left: 1px solid var(--light-gray); padding: 0.5rem 0;">
                             <div style="font-size: 1.5rem; font-weight: 600;"><?php echo $profile['article_count'] ?? 0; ?></div>
                             <div style="color: #666; font-size: 0.875rem;">Articles</div>
-                        </div>
-                        <div style="flex: 1; text-align: center; border-left: 1px solid var(--light-gray); padding: 0.5rem 0;">
-                            <div style="font-size: 1.5rem; font-weight: 600;"><?php echo $profile['follower_count'] ?? 0; ?></div>
-                            <div style="color: #666; font-size: 0.875rem;">Abonnés</div>
                         </div>
                     </div>
                 </div>

--- a/views/templates/header.php
+++ b/views/templates/header.php
@@ -59,19 +59,6 @@ global $api;
                             <a href="profile.php?id=<?php echo $user['id']; ?>">
                                 <i class="fas fa-user"></i> Mon Profil
                             </a>
-                            <a href="messages.php">
-                                <i class="fas fa-envelope"></i> Messages
-                                <?php
-                                try {
-                                    $unread_count = $api->request('/messages/unread-count', 'GET', [], true);
-                                    if ($unread_count['count'] > 0) {
-                                        echo '<span class="badge">' . $unread_count['count'] . '</span>';
-                                    }
-                                } catch (Exception $e) {
-                                    // Silently fail if we can't get message count
-                                }
-                                ?>
-                            </a>
                             <a href="settings.php">
                                 <i class="fas fa-cog"></i> Paramètres
                             </a>


### PR DESCRIPTION
## Summary
- strip message dropdown from header
- drop follow/message actions from profile
- drop follow/message actions from member listing
- delete messaging section from API guide

## Testing
- `python -m compileall -q || true`

------
https://chatgpt.com/codex/tasks/task_e_686f72ab6b748332abf367283f8ed40f