### PR TITLE
Add user bio update endpoint

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -49,6 +49,16 @@ Recuperer les informations d'un utilisateur.
 curl http://localhost:8000/users/1
 ```
 
+### PUT /users/{id}/bio
+Mettre a jour **uniquement** sa bio *(token requis)*.
+
+```bash
+curl -H "Authorization: Bearer <TOKEN>" \
+     -X PUT -H "Content-Type: application/json" \
+     -d '{"bio":"Ma nouvelle bio"}' \
+     http://localhost:8000/users/1/bio
+```
+
 ### GET /users/{id}/profile
 Afficher le profil detaille d'un utilisateur.
 
@@ -95,6 +105,16 @@ Recuperer les informations d'un utilisateur.
 
 ```bash
 curl http://localhost:8000/users/1
+```
+
+### PUT /users/{id}/bio
+Mettre a jour **uniquement** sa bio *(token requis)*.
+
+```bash
+curl -H "Authorization: Bearer <TOKEN>" \
+     -X PUT -H "Content-Type: application/json" \
+     -d '{"bio":"Ma nouvelle bio"}' \
+     http://localhost:8000/users/1/bio
 ```
 
 ### GET /users/{id}/profile

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The API will be available on port **8000** of the container. Replace
 
 - `POST /users` – create a new user (passwords are hashed server-side)
 - `GET /users/{id}` – retrieve a user
+- `PUT/PATCH /users/{id}/bio` – update your bio *(requires token)*
 - `POST /login` – obtain a JWT access token
 - `POST /logout` – revoke the current token
 - `POST /articles` – create an article *(requires token)*

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 import os
 import uuid
 import shutil
+import html
 
 from . import models, schemas
 from .database import Base, engine, get_db
@@ -106,6 +107,26 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user
+
+
+@app.put("/users/{user_id}/bio", response_model=schemas.UserOut)
+@app.patch("/users/{user_id}/bio", response_model=schemas.UserOut)
+def update_user_bio(
+    user_id: int,
+    data: schemas.UserBioUpdate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this user")
+    db_user = db.query(models.User).get(user_id)
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    sanitized_bio = html.escape(data.bio.strip()) if data.bio else ""
+    db_user.bio = sanitized_bio
+    db.commit()
+    db.refresh(db_user)
+    return db_user
 
 
 @app.get("/users/{user_id}/profile", response_model=schemas.UserProfileOut)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -23,6 +23,19 @@ class UserOut(UserBase):
         orm_mode = True
 
 
+class UserUpdate(BaseModel):
+    username: Optional[str] = None
+    email: Optional[str] = None
+    password: Optional[str] = None
+    bio: Optional[str] = None
+    avatar_url: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+class UserBioUpdate(BaseModel):
+    bio: str
+
+
 class ArticleBase(BaseModel):
     title: str
     content: str


### PR DESCRIPTION
## Summary
- restrict user updates to only modify their own bio
- sanitize bio updates to reduce XSS risk
- document the new `/users/{id}/bio` endpoint

## Testing
- `python -m py_compile backend/main.py backend/schemas.py`
- `python api_test.py` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_686f739b2d848332b23116e3fa02f2d3