### PR TITLE
Fix API URL builder and clarify PUT endpoint doc

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -54,6 +54,7 @@ curl http://localhost:8000/users/1
 
 ### PUT /users/{id}
 Mettre a jour son compte (username, email, mot de passe, bio, avatar). Token requis.
+Ne pas inclure de barre oblique finale dans l'URL (`/users/1` et non `/users/1/`).
 
 ```bash
 curl -H "Authorization: Bearer <TOKEN>" \

--- a/api.php
+++ b/api.php
@@ -20,7 +20,8 @@ class API {
      * @return array Response data
      */
     public function request($endpoint, $method = 'GET', $data = [], $auth = false, $json = true) {
-        $url = $this->base_url . $endpoint;
+        // Build URL without duplicate slashes
+        $url = rtrim($this->base_url, '/') . '/' . ltrim($endpoint, '/');
         $ch = curl_init();
         
         // Set method and data


### PR DESCRIPTION
## Summary
- avoid duplicate slashes when building API URLs
- document that `/users/{id}` should not use a trailing slash

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8cb425cc833291144184c5e5e4ee