### PR TITLE
Handle missing tags API on articles page

### DIFF
--- a/controllers/ArticlesController.php
+++ b/controllers/ArticlesController.php
@@ -18,12 +18,18 @@ class ArticlesController {
             $articles_data = $this->api->request($query);
             $total_count = $this->api->request('/articles/count' . (!empty($tag) ? '?tag=' . urlencode($tag) : ''));
             $total_pages = ceil(($total_count['count'] ?? 1) / 9);
-            $tags = $this->api->request('/tags');
         } catch (Exception $e) {
             $_SESSION['flash_message'] = "Erreur lors du chargement des articles: " . $e->getMessage();
             $_SESSION['flash_type'] = "error";
             $articles_data = [];
             $total_pages = 1;
+        }
+
+        // Charger la liste des tags séparément pour ne pas bloquer l'affichage des articles
+        try {
+            $tags = $this->api->request('/tags');
+        } catch (Exception $e) {
+            // Si l'API des tags n'est pas disponible, on continue sans les tags
             $tags = [];
         }
         require __DIR__ . '/../views/templates/header.php';


### PR DESCRIPTION
## Summary
- prevent articles list from failing when `/tags` is unavailable

## Testing
- `php -l controllers/ArticlesController.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f8f3b8cf08332b84d0a5f522ae83a