### PR TITLE
Handle missing view tracking endpoints

### DIFF
--- a/controllers/ArticleController.php
+++ b/controllers/ArticleController.php
@@ -19,7 +19,6 @@ class ArticleController {
             $comments = $this->api->request($endpoint_base . '/comments');
             // Use numeric ID from returned data for view tracking and comment posting
             $article_id = $article['id'];
-            $this->api->request('/articles/' . $article_id . '/view', 'POST');
             $page_title = $article['title'];
             $page_description = substr(strip_tags($article['content']), 0, 160);
         } catch (Exception $e) {
@@ -27,6 +26,13 @@ class ArticleController {
             $_SESSION['flash_type'] = "error";
             header('Location: articles.php');
             exit();
+        }
+
+        // Attempt to record the view count but don't block if the endpoint is missing
+        try {
+            $this->api->request('/articles/' . $article_id . '/view', 'POST');
+        } catch (Exception $e) {
+            // Silently ignore if the API doesn't support view tracking
         }
 
         $comment_error = '';

--- a/thread.php
+++ b/thread.php
@@ -17,9 +17,13 @@ try {
     
     // Get thread replies
     $replies = $api->request('/forum/threads/' . $thread_id . '/replies');
-    
-    // Update view count
-    $api->request('/forum/threads/' . $thread_id . '/view', 'POST');
+
+    // Update view count but continue even if the endpoint does not exist
+    try {
+        $api->request('/forum/threads/' . $thread_id . '/view', 'POST');
+    } catch (Exception $e) {
+        // Ignore missing view tracking endpoint
+    }
     
     $page_title = $thread['title'];
     $page_description = substr(strip_tags($thread['content']), 0, 160);


### PR DESCRIPTION
## Summary
- ignore failures from `/articles/{id}/view` in article controller
- ignore failures from `/forum/threads/{id}/view` in thread page

## Testing
- `php -l controllers/ArticleController.php`
- `php -l thread.php`
- `apt-get update`
- `apt-get install -y php-cli`

------
https://chatgpt.com/codex/tasks/task_e_686f90d962b08332adf9207756bdf3bc