### PR TITLE
Fix user list page when count API fails

### DIFF
--- a/membres.php
+++ b/membres.php
@@ -31,23 +31,29 @@ switch ($sort) {
         break;
 }
 
+// Récupération des membres
 try {
-    // Get members
     $query = '/users?skip=' . $skip . '&limit=' . $limit . $sort_param;
     if (!empty($search)) {
         $query .= '&search=' . urlencode($search);
     }
-    
+
     $members_data = $api->request($query);
-    
-    // Get total count for pagination
-    $total_count = $api->request('/users/count' . (!empty($search) ? '?search=' . urlencode($search) : ''));
-    $total_pages = ceil(($total_count['count'] ?? 24) / $limit);
-    
 } catch (Exception $e) {
     $_SESSION['flash_message'] = "Erreur lors du chargement des membres: " . $e->getMessage();
     $_SESSION['flash_type'] = "error";
     $members_data = [];
+}
+
+// Pagination (ne doit pas masquer la liste si le comptage échoue)
+try {
+    $total_count = $api->request('/users/count' . (!empty($search) ? '?search=' . urlencode($search) : ''));
+    $total_pages = ceil(($total_count['count'] ?? 24) / $limit);
+} catch (Exception $e) {
+    if (!isset($_SESSION['flash_message'])) {
+        $_SESSION['flash_message'] = "Erreur lors du chargement du nombre de membres: " . $e->getMessage();
+        $_SESSION['flash_type'] = "error";
+    }
     $total_pages = 1;
 }
 ?>


### PR DESCRIPTION
## Summary
- avoid wiping member list if `/users/count` is unavailable
- report a separate error when the count request fails

## Testing
- `php -l membres.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9d1ba4a88332a6a3ef2829da842c