### PR TITLE
Remove unused view counts

### DIFF
--- a/category.php
+++ b/category.php
@@ -73,7 +73,6 @@ include 'header.php';
                                 <a href="thread.php?id=<?php echo $thread['id']; ?>" class="topic-title"><?php echo htmlspecialchars($thread['title']); ?></a>
                                 <div class="topic-stats">
                                     <span><i class="fas fa-comment"></i> <?php echo $thread['reply_count'] ?? 0; ?> réponses</span>
-                                    <span><i class="fas fa-eye"></i> <?php echo $thread['view_count'] ?? 0; ?> vues</span>
                                 </div>
                             </div>
                             <div class="topic-last-post">

--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -148,7 +148,6 @@ try {
                                             <a href="thread.php?id=<?php echo $thread['id']; ?>" class="topic-title"><?php echo htmlspecialchars($thread['title']); ?></a>
                                             <div class="topic-stats">
                                                 <span><i class="fas fa-comment"></i> <?php echo $thread['reply_count'] ?? 0; ?> réponses</span>
-                                                <span><i class="fas fa-eye"></i> <?php echo $thread['view_count'] ?? 0; ?> vues</span>
                                             </div>
                                         </div>
                                         <div class="topic-last-post">

--- a/dev.php
+++ b/dev.php
@@ -153,7 +153,6 @@ console.table(users, ['name', 'role']);</code></pre>
                                             <a href="thread.php?id=<?php echo $thread['id']; ?>" class="topic-title"><?php echo htmlspecialchars($thread['title']); ?></a>
                                             <div class="topic-stats">
                                                 <span><i class="fas fa-comment"></i> <?php echo $thread['reply_count'] ?? 0; ?> réponses</span>
-                                                <span><i class="fas fa-eye"></i> <?php echo $thread['view_count'] ?? 0; ?> vues</span>
                                             </div>
                                         </div>
                                         <div class="topic-last-post">

--- a/my-content.php
+++ b/my-content.php
@@ -95,7 +95,6 @@ include 'header.php';
                             <tr>
                                 <th style="text-align: left; padding: 1rem;">Titre</th>
                                 <th style="text-align: center; padding: 1rem;">Date de publication</th>
-                                <th style="text-align: center; padding: 1rem;">Vues</th>
                                 <th style="text-align: center; padding: 1rem;">Commentaires</th>
                                 <th style="text-align: center; padding: 1rem;">Actions</th>
                             </tr>
@@ -110,9 +109,6 @@ include 'header.php';
                                     </td>
                                     <td style="text-align: center; padding: 1rem; border-top: 1px solid var(--light-gray);">
                                         <?php echo date('d/m/Y', strtotime($article['created_at'])); ?>
-                                    </td>
-                                    <td style="text-align: center; padding: 1rem; border-top: 1px solid var(--light-gray);">
-                                        <?php echo $article['view_count'] ?? 0; ?>
                                     </td>
                                     <td style="text-align: center; padding: 1rem; border-top: 1px solid var(--light-gray);">
                                         <?php echo $article['comment_count'] ?? 0; ?>

--- a/profile.php
+++ b/profile.php
@@ -175,7 +175,6 @@ include 'header.php';
                                                 </div>
                                                 <div style="display: flex; gap: 1rem; color: #666; font-size: 0.875rem;">
                                                     <div><i class="fas fa-comment"></i> <?php echo $thread['reply_count'] ?? 0; ?></div>
-                                                    <div><i class="fas fa-eye"></i> <?php echo $thread['view_count'] ?? 0; ?></div>
                                                 </div>
                                             </div>
                                         </div>
@@ -221,7 +220,6 @@ include 'header.php';
                                                 </div>
                                                 <div style="display: flex; gap: 1rem; color: #666; font-size: 0.875rem;">
                                                     <div><i class="far fa-comment"></i> <?php echo $article['comment_count'] ?? 0; ?></div>
-                                                    <div><i class="far fa-eye"></i> <?php echo $article['view_count'] ?? 0; ?></div>
                                                 </div>
                                             </div>
                                         </div>

--- a/search.php
+++ b/search.php
@@ -159,7 +159,6 @@ function highlightSearchTerms($text, $search) {
                                     <div class="search-meta" style="margin-bottom: 1rem; font-size: 0.875rem; color: #666;">
                                         <span><i class="fas fa-user"></i> <?php echo htmlspecialchars($article['username'] ?? 'Auteur'); ?></span> &bull;
                                         <span><i class="far fa-calendar"></i> <?php echo date('d/m/Y', strtotime($article['created_at'])); ?></span> &bull;
-                                        <span><i class="far fa-eye"></i> <?php echo $article['view_count'] ?? 0; ?> vues</span>
                                         
                                         <?php if (isset($article['tags']) && !empty($article['tags'])): ?>
                                             &bull;
@@ -215,7 +214,6 @@ function highlightSearchTerms($text, $search) {
                                         <span><i class="fas fa-user"></i> <?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></span> &bull;
                                         <span><i class="far fa-calendar"></i> <?php echo date('d/m/Y', strtotime($thread['created_at'])); ?></span> &bull;
                                         <span><i class="far fa-comment"></i> <?php echo $thread['reply_count'] ?? 0; ?> réponses</span> &bull;
-                                        <span><i class="far fa-eye"></i> <?php echo $thread['view_count'] ?? 0; ?> vues</span>
                                         
                                         <?php if (isset($thread['category']) && !empty($thread['category'])): ?>
                                             &bull;

--- a/views/article.php
+++ b/views/article.php
@@ -41,7 +41,6 @@
                     </div>
                     <div><i class="far fa-calendar"></i> <?php echo date('d/m/Y', strtotime($article['created_at'])); ?></div>
                     <div><i class="far fa-clock"></i> <?php echo isset($article['read_time']) ? $article['read_time'] . ' min de lecture' : 'Lecture'; ?></div>
-                    <div><i class="far fa-eye"></i> <?php echo $article['view_count'] ?? 0; ?> vues</div>
                 </div>
             </div>
             

--- a/views/forums.php
+++ b/views/forums.php
@@ -81,7 +81,6 @@
                                                         <a href="thread.php?id=<?php echo $thread['id']; ?>" class="topic-title"><?php echo htmlspecialchars($thread['title']); ?></a>
                                                         <div class="topic-stats">
                                                             <span><i class="fas fa-comment"></i> <?php echo $thread['reply_count'] ?? 0; ?> réponses</span>
-                                                            <span><i class="fas fa-eye"></i> <?php echo $thread['view_count'] ?? 0; ?> vues</span>
                                                         </div>
                                                     </div>
                                                     <div class="topic-last-post">

--- a/views/home.php
+++ b/views/home.php
@@ -60,7 +60,6 @@
                                                     <a href="thread.php?id=<?php echo $thread['id']; ?>" class="topic-title"><?php echo htmlspecialchars($thread['title']); ?></a>
                                                     <div class="topic-stats">
                                                         <span><i class="fas fa-comment"></i> <?php echo $thread['reply_count'] ?? 0; ?> réponses</span>
-                                                        <span><i class="fas fa-eye"></i> <?php echo $thread['view_count'] ?? 0; ?> vues</span>
                                                     </div>
                                                 </div>
                                                 <div class="topic-last-post">
@@ -228,7 +227,6 @@
                                         <a href="thread.php?id=<?php echo $thread['id']; ?>" style="font-weight: 500;"><?php echo htmlspecialchars($thread['title']); ?></a>
                                         <div style="font-size: 0.8125rem; color: #666; margin-top: 0.25rem;">
                                             <span><?php echo $thread['reply_count'] ?? 0; ?> réponses</span>
-                                            <span style="margin-left: 0.5rem;"><?php echo $thread['view_count'] ?? 0; ?> vues</span>
                                         </div>
                                     </li>
                                 <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- drop the "Vues" column from article management
- clean up references to `view_count` across templates

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9dbd489883328403d6a04cd96115