### PR TITLE
Add user listing endpoints

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -49,6 +49,25 @@ Recuperer les informations d'un utilisateur.
 curl http://localhost:8000/users/1
 ```
 
+### GET /users
+Lister les utilisateurs.
+
+Parametres query :
+- `skip` (defaut 0)
+- `limit` (defaut 10)
+- `sort` : `newest` ou `oldest`
+
+```bash
+curl "http://localhost:8000/users?skip=0&limit=24&sort=newest"
+```
+
+### GET /users/count
+Nombre total d'utilisateurs inscrits.
+
+```bash
+curl http://localhost:8000/users/count
+```
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The API will be available on port **8000** of the container. Replace
 
 - `POST /users` – create a new user (passwords are hashed server-side)
 - `GET /users/{id}` – retrieve a user
+- `GET /users` – list users
+- `GET /users/count` – total number of users
 - `PUT/PATCH /users/{id}` – update account information *(requires token)*
 - `PUT/PATCH /users/{id}/bio` – update your bio *(requires token)*
 - `POST /login` – obtain a JWT access token

--- a/backend/main.py
+++ b/backend/main.py
@@ -101,6 +101,28 @@ def logout(token: str = Depends(oauth2_scheme)):
     return {"detail": "Logged out"}
 
 
+@app.get("/users", response_model=List[schemas.UserOut])
+def list_users(
+    skip: int = 0,
+    limit: int = 10,
+    sort: str = "newest",
+    db: Session = Depends(get_db),
+):
+    """List users with optional pagination and sorting."""
+    query = db.query(models.User)
+    if sort == "newest":
+        query = query.order_by(models.User.created_at.desc())
+    elif sort == "oldest":
+        query = query.order_by(models.User.created_at)
+    return query.offset(skip).limit(limit).all()
+
+
+@app.get("/users/count", response_model=schemas.CountOut)
+def count_users(db: Session = Depends(get_db)):
+    """Return the total number of registered users."""
+    return {"count": db.query(models.User).count()}
+
+
 @app.get("/users/{user_id}", response_model=schemas.UserOut)
 def read_user(user_id: int, db: Session = Depends(get_db)):
     user = db.query(models.User).get(user_id)


### PR DESCRIPTION
## Summary
- implement `GET /users` and `GET /users/count` endpoints
- document new endpoints in README and API_DEV_GUIDE

## Testing
- `python -m py_compile backend/main.py`
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686fa300632083329b69d4470796ed49