### PR TITLE
Fix member search and use remote default avatar

### DIFF
--- a/config.php
+++ b/config.php
@@ -16,6 +16,9 @@ define('COLOR_DARK_BLUE', '#23255D');
 define('COLOR_NEAR_BLACK', '#191920');
 define('COLOR_ACCENT_RED', '#E6213A');
 
+// Default avatar image URL for users without a profile picture
+define('DEFAULT_AVATAR_URL', 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y');
+
 // Session timeout (in seconds)
 define('SESSION_TIMEOUT', 3600); // 1 hour
 

--- a/membres.php
+++ b/membres.php
@@ -33,12 +33,15 @@ switch ($sort) {
 
 // Récupération des membres
 try {
-    $query = '/users?skip=' . $skip . '&limit=' . $limit . $sort_param;
     if (!empty($search)) {
-        $query .= '&search=' . urlencode($search);
+        // Utiliser l'endpoint de recherche lorsque l'utilisateur saisit une requête
+        $search_query = '/search?q=' . urlencode($search) . '&type=users&skip=' . $skip . '&limit=' . $limit;
+        $search_result = $api->request($search_query);
+        $members_data = $search_result['users'] ?? [];
+    } else {
+        $query = '/users?skip=' . $skip . '&limit=' . $limit . $sort_param;
+        $members_data = $api->request($query);
     }
-
-    $members_data = $api->request($query);
 } catch (Exception $e) {
     $_SESSION['flash_message'] = "Erreur lors du chargement des membres: " . $e->getMessage();
     $_SESSION['flash_type'] = "error";
@@ -47,8 +50,13 @@ try {
 
 // Pagination (ne doit pas masquer la liste si le comptage échoue)
 try {
-    $total_count = $api->request('/users/count' . (!empty($search) ? '?search=' . urlencode($search) : ''));
-    $total_pages = ceil(($total_count['count'] ?? 24) / $limit);
+    if (!empty($search)) {
+        $count_result = $api->request('/search/count?q=' . urlencode($search) . '&type=users');
+        $total_pages = ceil(($count_result['count'] ?? 24) / $limit);
+    } else {
+        $total_count = $api->request('/users/count');
+        $total_pages = ceil(($total_count['count'] ?? 24) / $limit);
+    }
 } catch (Exception $e) {
     if (!isset($_SESSION['flash_message'])) {
         $_SESSION['flash_message'] = "Erreur lors du chargement du nombre de membres: " . $e->getMessage();
@@ -101,7 +109,7 @@ try {
                     <div class="member-card" style="background-color: var(--white); border-radius: var(--border-radius); overflow: hidden; box-shadow: 0 2px 10px rgba(0,0,0,0.05);">
                         <div style="padding: 1.5rem; text-align: center; border-bottom: 1px solid var(--light-gray);">
                             <div class="member-avatar" style="position: relative; display: inline-block; margin-bottom: 1rem;">
-                                <img src="<?php echo isset($member['avatar_url']) && !empty($member['avatar_url']) ? htmlspecialchars($member['avatar_url']) : 'assets/images/default-avatar.png'; ?>" alt="Avatar" style="width: 80px; height: 80px; border-radius: 50%; object-fit: cover;">
+                                <img src="<?php echo isset($member['avatar_url']) && !empty($member['avatar_url']) ? htmlspecialchars($member['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" style="width: 80px; height: 80px; border-radius: 50%; object-fit: cover;">
                                 
                                 <?php if (isset($member['is_online']) && $member['is_online']): ?>
                                     <div class="online-indicator" style="position: absolute; bottom: 0; right: 0; width: 16px; height: 16px; background-color: #28a745; border-radius: 50%; border: 2px solid white;"></div>

--- a/profile.php
+++ b/profile.php
@@ -72,7 +72,7 @@ include 'header.php';
                 <div class="forum-container" style="margin-bottom: 2rem;">
                     <div class="profile-header" style="padding: 2rem; display: flex; align-items: center; gap: 2rem; flex-wrap: wrap;">
                         <div class="profile-avatar" style="flex-shrink: 0;">
-                            <img src="<?php echo isset($profile['avatar_url']) && !empty($profile['avatar_url']) ? htmlspecialchars($profile['avatar_url']) : 'assets/images/default-avatar.png'; ?>" alt="Avatar" style="width: 120px; height: 120px; border-radius: 50%; object-fit: cover;">
+                            <img src="<?php echo isset($profile['avatar_url']) && !empty($profile['avatar_url']) ? htmlspecialchars($profile['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" style="width: 120px; height: 120px; border-radius: 50%; object-fit: cover;">
                         </div>
                         
                         <div class="profile-info" style="flex-grow: 1; min-width: 200px;">

--- a/search.php
+++ b/search.php
@@ -258,7 +258,7 @@ function highlightSearchTerms($text, $search) {
                         <div class="search-list grid grid-3" style="gap: 1rem;">
                             <?php foreach ($users as $user): ?>
                                 <div class="search-item" style="padding: 1.5rem; background-color: var(--white); border-radius: var(--border-radius); box-shadow: 0 2px 10px rgba(0,0,0,0.05); display: flex; align-items: center;">
-                                    <img src="<?php echo isset($user['avatar_url']) && !empty($user['avatar_url']) ? htmlspecialchars($user['avatar_url']) : 'assets/images/default-avatar.png'; ?>" alt="Avatar" style="width: 50px; height: 50px; border-radius: 50%; object-fit: cover; margin-right: 1rem;">
+                                    <img src="<?php echo isset($user['avatar_url']) && !empty($user['avatar_url']) ? htmlspecialchars($user['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" style="width: 50px; height: 50px; border-radius: 50%; object-fit: cover; margin-right: 1rem;">
                                     
                                     <div style="flex: 1;">
                                         <h4 style="margin: 0 0 0.25rem;">

--- a/thread.php
+++ b/thread.php
@@ -97,7 +97,7 @@ include 'header.php';
             <!-- Original Post -->
             <div class="post">
                 <div class="post-sidebar">
-                    <img src="<?php echo isset($thread['user']['avatar_url']) && !empty($thread['user']['avatar_url']) ? htmlspecialchars($thread['user']['avatar_url']) : 'assets/kopologovide.png'; ?>" alt="Avatar" class="user-avatar">
+                    <img src="<?php echo isset($thread['user']['avatar_url']) && !empty($thread['user']['avatar_url']) ? htmlspecialchars($thread['user']['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" class="user-avatar">
                     <div class="user-name"><?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></div>
                     <div class="user-info">
                         <?php
@@ -150,7 +150,7 @@ include 'header.php';
                     <?php foreach ($replies as $reply): ?>
                         <div class="post" id="reply-<?php echo $reply['id']; ?>">
                             <div class="post-sidebar">
-                                <img src="<?php echo isset($reply['user']['avatar_url']) && !empty($reply['user']['avatar_url']) ? htmlspecialchars($reply['user']['avatar_url']) : 'assets/kopologovide.png'; ?>" alt="Avatar" class="user-avatar">
+                                <img src="<?php echo isset($reply['user']['avatar_url']) && !empty($reply['user']['avatar_url']) ? htmlspecialchars($reply['user']['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" class="user-avatar">
                                 <div class="user-name"><?php echo htmlspecialchars($reply['username'] ?? 'Utilisateur'); ?></div>
                                 <div class="user-info">
                                     <?php

--- a/views/article.php
+++ b/views/article.php
@@ -34,7 +34,7 @@
                 
                 <div class="article-meta">
                     <div class="article-author">
-                        <img src="<?php echo isset($article['author']['avatar_url']) && !empty($article['author']['avatar_url']) ? htmlspecialchars($article['author']['avatar_url']) : 'assets/kopologovide.png'; ?>" alt="Avatar" class="article-author-avatar">
+                        <img src="<?php echo isset($article['author']['avatar_url']) && !empty($article['author']['avatar_url']) ? htmlspecialchars($article['author']['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" class="article-author-avatar">
                         <div>
                             <a href="profile.php?id=<?php echo $article['user_id']; ?>"><?php echo htmlspecialchars($article['username'] ?? 'Auteur'); ?></a>
                         </div>

--- a/views/forums.php
+++ b/views/forums.php
@@ -147,7 +147,7 @@
                         <div class="widget-content" style="text-align: center;">
                             <?php $user = $api->getCurrentUser(); ?>
                             <div style="margin-bottom: 1rem;">
-                                <img src="<?php echo isset($user['avatar_url']) && !empty($user['avatar_url']) ? htmlspecialchars($user['avatar_url']) : 'assets/kopologovide.png'; ?>" alt="Avatar" class="user-avatar" style="margin: 0 auto 0.5rem; width: 80px; height: 80px;">
+                                <img src="<?php echo isset($user['avatar_url']) && !empty($user['avatar_url']) ? htmlspecialchars($user['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" class="user-avatar" style="margin: 0 auto 0.5rem; width: 80px; height: 80px;">
                                 <h4 style="margin: 0;"><?php echo htmlspecialchars($user['username']); ?></h4>
                                 <div style="color: #666; font-size: 0.875rem;">
                                     Membre depuis <?php echo date('M Y', strtotime($user['created_at'])); ?>


### PR DESCRIPTION
## Summary
- query the `/search` endpoint for member lists when searching
- compute pagination from `/search/count`
- add `DEFAULT_AVATAR_URL` constant and use it whenever no avatar is set
- remove the local `default-avatar.png` file

## Testing
- `php -l membres.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa7c627fc8332943e355fb2f514cb