### PR TITLE
Implement tag assignment at creation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -223,9 +223,14 @@ def create_article(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
-    db_article = models.Article(**article.dict())
+    data = article.dict()
+    tag_id = data.pop("tag_id", None)
+    db_article = models.Article(**data)
     db.add(db_article)
     db.commit()
+    if tag_id:
+        db.add(models.ArticleTag(article_id=db_article.id, tag_id=tag_id))
+        db.commit()
     db.refresh(db_article)
     return db_article
 
@@ -260,8 +265,14 @@ def update_article(
     db_article = db.query(models.Article).get(article_id)
     if not db_article:
         raise HTTPException(status_code=404, detail="Article not found")
-    for key, value in article.dict(exclude_unset=True).items():
+    data = article.dict(exclude_unset=True)
+    tag_id = data.pop("tag_id", None)
+    for key, value in data.items():
         setattr(db_article, key, value)
+    if tag_id is not None:
+        db.query(models.ArticleTag).filter(models.ArticleTag.article_id == article_id).delete()
+        if tag_id:
+            db.add(models.ArticleTag(article_id=article_id, tag_id=tag_id))
     db.commit()
     db.refresh(db_article)
     return db_article
@@ -356,9 +367,14 @@ def create_thread(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
-    db_thread = models.ForumThread(**thread.dict())
+    data = thread.dict()
+    tag_id = data.pop("tag_id", None)
+    db_thread = models.ForumThread(**data)
     db.add(db_thread)
     db.commit()
+    if tag_id:
+        db.add(models.ThreadTag(thread_id=db_thread.id, tag_id=tag_id))
+        db.commit()
     db.refresh(db_thread)
     return db_thread
 
@@ -387,8 +403,14 @@ def update_thread(
     db_thread = db.query(models.ForumThread).get(thread_id)
     if not db_thread:
         raise HTTPException(status_code=404, detail="Thread not found")
-    for key, value in thread.dict(exclude_unset=True).items():
+    data = thread.dict(exclude_unset=True)
+    tag_id = data.pop("tag_id", None)
+    for key, value in data.items():
         setattr(db_thread, key, value)
+    if tag_id is not None:
+        db.query(models.ThreadTag).filter(models.ThreadTag.thread_id == thread_id).delete()
+        if tag_id:
+            db.add(models.ThreadTag(thread_id=thread_id, tag_id=tag_id))
     db.commit()
     db.refresh(db_thread)
     return db_thread

--- a/backend/models.py
+++ b/backend/models.py
@@ -105,6 +105,10 @@ class Article(Base):
     comments = relationship('Comment', back_populates='article')
     article_tags = relationship('ArticleTag', back_populates='article')
 
+    @property
+    def tag_id(self):
+        return self.article_tags[0].tag_id if self.article_tags else None
+
 
 class Tag(Base):
     __tablename__ = 'tags'
@@ -113,6 +117,7 @@ class Tag(Base):
     name = Column(String(50), unique=True, nullable=False)
 
     article_tags = relationship('ArticleTag', back_populates='tag')
+    thread_tags = relationship('ThreadTag', back_populates='tag')
 
 
 class ArticleTag(Base):
@@ -122,6 +127,15 @@ class ArticleTag(Base):
 
     article = relationship('Article', back_populates='article_tags')
     tag = relationship('Tag', back_populates='article_tags')
+
+
+class ThreadTag(Base):
+    __tablename__ = 'thread_tags'
+    thread_id = Column(Integer, ForeignKey('forum_threads.id', ondelete='CASCADE'), primary_key=True)
+    tag_id = Column(Integer, ForeignKey('tags.id', ondelete='CASCADE'), primary_key=True)
+
+    thread = relationship('ForumThread', back_populates='thread_tags')
+    tag = relationship('Tag', back_populates='thread_tags')
 
 
 class Comment(Base):
@@ -166,6 +180,11 @@ class ForumThread(Base):
     user = relationship('User', back_populates='threads')
     category = relationship('ForumCategory', back_populates='threads')
     replies = relationship('ForumReply', back_populates='thread')
+    thread_tags = relationship('ThreadTag', back_populates='thread')
+
+    @property
+    def tag_id(self):
+        return self.thread_tags[0].tag_id if self.thread_tags else None
 
 
 class ForumReply(Base):

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -44,6 +44,7 @@ class ArticleBase(BaseModel):
 
 class ArticleCreate(ArticleBase):
     user_id: Optional[int]
+    tag_id: Optional[int] = None
 
 
 class ArticleUpdate(BaseModel):
@@ -51,11 +52,13 @@ class ArticleUpdate(BaseModel):
     content: Optional[str] = None
     is_pub: Optional[bool] = None
     user_id: Optional[int] = None
+    tag_id: Optional[int] = None
 
 
 class ArticleOut(ArticleBase):
     id: int
     user_id: Optional[int]
+    tag_id: Optional[int] = None
     created_at: datetime
     updated_at: datetime
 
@@ -120,6 +123,7 @@ class ForumThreadBase(BaseModel):
 
 class ForumThreadCreate(ForumThreadBase):
     user_id: Optional[int]
+    tag_id: Optional[int] = None
 
 
 class ForumThreadUpdate(BaseModel):
@@ -127,6 +131,7 @@ class ForumThreadUpdate(BaseModel):
     content: Optional[str] = None
     category_id: Optional[int] = None
     user_id: Optional[int] = None
+    tag_id: Optional[int] = None
     is_locked: Optional[bool] = None
     is_pinned: Optional[bool] = None
 
@@ -134,6 +139,7 @@ class ForumThreadUpdate(BaseModel):
 class ForumThreadOut(ForumThreadBase):
     id: int
     user_id: Optional[int]
+    tag_id: Optional[int] = None
     is_locked: bool
     is_pinned: bool
     created_at: datetime
@@ -289,6 +295,14 @@ class ArticleTagCreate(BaseModel):
 
 class ArticleTagOut(ArticleTagCreate):
     article_id: int
+
+
+class ThreadTagCreate(BaseModel):
+    tag_id: int
+
+
+class ThreadTagOut(ThreadTagCreate):
+    thread_id: int
 
 
 class PasswordResetRequest(BaseModel):


### PR DESCRIPTION
## Summary
- support tag assignment when creating or updating articles and threads
- expose tag_id in API schemas
- add models to store tags on forum threads

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686faa58d4c08332a9a487f0471daacf