### PR TITLE
Enable creating custom tags

### DIFF
--- a/edit-article.php
+++ b/edit-article.php
@@ -60,6 +60,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_toke
     $title = isset($_POST['title']) ? sanitize_string($_POST['title']) : '';
     $content = isset($_POST['content']) ? sanitize_string($_POST['content']) : '';
     $selected_tags = isset($_POST['tags']) ? array_map('sanitize_int', (array)$_POST['tags']) : [];
+    $new_tag = isset($_POST['new_tag']) ? sanitize_string($_POST['new_tag']) : '';
     $is_published = isset($_POST['is_published']) ? true : false;
 
     // Basic validation
@@ -69,6 +70,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_toke
         $error = "Le contenu ne peut pas être vide.";
     } else {
         try {
+            // Create tag if user provided one
+            if (!empty($new_tag)) {
+                try {
+                    $tagResult = $api->request('/tags', 'POST', ['name' => $new_tag], true);
+                    if (isset($tagResult['id'])) {
+                        $selected_tags[] = $tagResult['id'];
+                        $tags[] = ['id' => $tagResult['id'], 'name' => $new_tag];
+                    }
+                } catch (Exception $e) {
+                    $error = "Erreur lors de la création du tag: " . $e->getMessage();
+                }
+            }
+
             // Update article
             $article_data = [
                 'title' => $title,
@@ -224,6 +238,12 @@ code sur plusieurs lignes
                                 <?php endif; ?>
                             </select>
                             <div class="form-text">Vous pouvez sélectionner plusieurs tags en maintenant la touche Ctrl (ou Cmd sur Mac).</div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="new_tag" class="form-label">Ajouter un tag</label>
+                            <input type="text" id="new_tag" name="new_tag" class="form-control" placeholder="Nouveau tag">
+                            <div class="form-text">Si le tag n'existe pas encore, il sera créé puis associé à l'article.</div>
                         </div>
                         
                         <?php if (isset($article['image_url']) && !empty($article['image_url'])): ?>

--- a/new-article.php
+++ b/new-article.php
@@ -30,6 +30,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_toke
     $title = isset($_POST['title']) ? sanitize_string($_POST['title']) : '';
     $content = isset($_POST['content']) ? sanitize_string($_POST['content']) : '';
     $selected_tags = isset($_POST['tags']) ? array_map('sanitize_int', (array)$_POST['tags']) : [];
+    $new_tag = isset($_POST['new_tag']) ? sanitize_string($_POST['new_tag']) : '';
     $is_published = isset($_POST['is_published']) ? true : false;
 
     // Basic validation
@@ -39,6 +40,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_toke
         $error = "Le contenu ne peut pas être vide.";
     } else {
         try {
+            // Create tag if user provided one
+            if (!empty($new_tag)) {
+                try {
+                    $tagResult = $api->request('/tags', 'POST', ['name' => $new_tag], true);
+                    if (isset($tagResult['id'])) {
+                        $selected_tags[] = $tagResult['id'];
+                        $tags[] = ['id' => $tagResult['id'], 'name' => $new_tag];
+                    }
+                } catch (Exception $e) {
+                    $error = "Erreur lors de la création du tag: " . $e->getMessage();
+                }
+            }
+
             // Create article first
             $article_data = [
                 'title' => $title,
@@ -190,6 +204,12 @@ code sur plusieurs lignes
                                 <?php endif; ?>
                             </select>
                             <div class="form-text">Vous pouvez sélectionner plusieurs tags en maintenant la touche Ctrl (ou Cmd sur Mac).</div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="new_tag" class="form-label">Ajouter un tag</label>
+                            <input type="text" id="new_tag" name="new_tag" class="form-control" placeholder="Nouveau tag">
+                            <div class="form-text">Si le tag n'existe pas encore, il sera créé puis associé à l'article.</div>
                         </div>
                         
                         <div class="form-group">


### PR DESCRIPTION
## Summary
- allow adding new tags when submitting article forms
- append new tag ID to selected tag list on creation/edit
- add "Ajouter un tag" input field on article forms

## Testing
- `php -l new-article.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686fb57ada448332950d137c408f075c