### PR TITLE
Fix article creation with required user_id

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -153,10 +153,10 @@ curl -X PUT -H "Content-Type: application/json" \
 Creer un nouvel article.
 
 Corps JSON :
-- `title`
-- `content`
-- `user_id` (optionnel)
-- `is_pub` (bool, defaut `false`)
+ - `title`
+ - `content`
+ - `user_id` (requis)
+ - `is_pub` (bool, defaut `false`)
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/new-article.php
+++ b/new-article.php
@@ -55,10 +55,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_toke
             }
 
             // Create article first
+            $user = $api->getCurrentUser();
             $article_data = [
                 'title' => $title,
                 'content' => $content,
-                'is_pub' => $is_published
+                'is_pub' => $is_published,
+                'user_id' => $user['id'] ?? null
             ];
             
             $result = $api->request('/articles', 'POST', $article_data, true);


### PR DESCRIPTION
## Summary
- include `user_id` when creating an article so FastAPI validation succeeds
- clarify in API dev guide that `user_id` is required for creating articles

## Testing
- `php -l new-article.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbb7295608332a72e9708e9dd3959