### PR TITLE
Add topic-based content filtering

### DIFF
--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -1,15 +1,35 @@
 <?php
 $page_title = "Cybersécurité";
 $page_description = "Information et discussions sur la cybersécurité, les vulnérabilités, la sécurité informatique et la protection des données";
+require_once 'functions.php';
 require_once 'header.php';
 
 try {
-    // Get security articles with cybersecurity tag
-    $security_articles = $api->request('/articles?tag=cybersécurité&limit=6');
-    
-    // Get security forum threads
-    $security_threads = $api->request('/forum/threads?category=security&limit=5');
-    
+    // Load recent articles then filter by cybersecurity keywords
+    $all_articles = $api->request('/articles?limit=20');
+    $security_articles = [];
+    foreach ($all_articles as $article) {
+        $tags = array_column($article['tags'] ?? [], 'name');
+        if (detect_topic($tags, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'security') {
+            $security_articles[] = $article;
+        }
+        if (count($security_articles) >= 6) {
+            break;
+        }
+    }
+
+    // Load forum threads and filter them as well
+    $all_threads = $api->request('/forum/threads?limit=20');
+    $security_threads = [];
+    foreach ($all_threads as $thread) {
+        if (detect_topic([], ($thread['title'] ?? '') . ' ' . ($thread['content'] ?? '')) === 'security') {
+            $security_threads[] = $thread;
+        }
+        if (count($security_threads) >= 5) {
+            break;
+        }
+    }
+
     // Get latest security alerts
     $security_alerts = $api->request('/security/alerts?limit=3');
     

--- a/dev.php
+++ b/dev.php
@@ -1,15 +1,35 @@
 <?php
 $page_title = "Développement";
 $page_description = "Ressources, articles et discussions sur le développement informatique, la programmation et les langages de code";
+require_once 'functions.php';
 require_once 'header.php';
 
 try {
-    // Get dev articles
-    $dev_articles = $api->request('/articles?tag=développement&limit=6');
-    
-    // Get dev forum threads
-    $dev_threads = $api->request('/forum/threads?category=dev&limit=5');
-    
+    // Load recent articles then filter by development keywords
+    $all_articles = $api->request('/articles?limit=20');
+    $dev_articles = [];
+    foreach ($all_articles as $article) {
+        $tags = array_column($article['tags'] ?? [], 'name');
+        if (detect_topic($tags, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'dev') {
+            $dev_articles[] = $article;
+        }
+        if (count($dev_articles) >= 6) {
+            break;
+        }
+    }
+
+    // Load forum threads and filter them as well
+    $all_threads = $api->request('/forum/threads?limit=20');
+    $dev_threads = [];
+    foreach ($all_threads as $thread) {
+        if (detect_topic([], ($thread['title'] ?? '') . ' ' . ($thread['content'] ?? '')) === 'dev') {
+            $dev_threads[] = $thread;
+        }
+        if (count($dev_threads) >= 5) {
+            break;
+        }
+    }
+
     // Get trending technologies
     $trending_techs = $api->request('/technologies/trending?limit=5');
     

--- a/functions.php
+++ b/functions.php
@@ -20,4 +20,38 @@ function csrf_token() {
 function verify_csrf_token($token) {
     return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
 }
+
+/**
+ * Detect the topic of a piece of content based on tags/keywords.
+ * Returns 'dev' for development, 'security' for cybersecurity or null if no
+ * match is found.
+ *
+ * @param array $tags    List of tag names
+ * @param string $content Content or title to analyse
+ * @return string|null
+ */
+function detect_topic(array $tags = [], string $content = '') {
+    $dev_keywords = [
+        'dev', 'développement', 'programmation', 'code', 'framework', 'web',
+        'mobile', 'ia', 'devops'
+    ];
+    $security_keywords = [
+        'cyber', 'sécurité', 'securite', 'hacking', 'pentest', 'vuln',
+        'vulnérabilité', 'vulnerabilite', 'cryptographie', 'protection des données'
+    ];
+
+    $text = strtolower($content . ' ' . implode(' ', $tags));
+
+    foreach ($dev_keywords as $kw) {
+        if (strpos($text, $kw) !== false) {
+            return 'dev';
+        }
+    }
+    foreach ($security_keywords as $kw) {
+        if (strpos($text, $kw) !== false) {
+            return 'security';
+        }
+    }
+    return null;
+}
 ?>


### PR DESCRIPTION
## Summary
- add a `detect_topic` helper to recognise dev or security related content
- filter articles and threads for the *Cybersécurité* and *Développement* pages using this helper
- ensure these pages load the helper functions

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc093f5dc8332b9c0cd7c57aef29e