### PR TITLE
Improve tag selection UI

### DIFF
--- a/edit-article.php
+++ b/edit-article.php
@@ -231,17 +231,10 @@ code sur plusieurs lignes
                         </div>
                         
                         <div class="form-group">
-                            <label for="tags" class="form-label">Tags</label>
-                            <select id="tags" name="tags[]" class="form-control" multiple>
-                                <?php if (!empty($tags)): ?>
-                                    <?php foreach ($tags as $tag): ?>
-                                        <option value="<?php echo $tag['id']; ?>" <?php echo in_array($tag['id'], $selected_tag_ids) ? 'selected' : ''; ?>>
-                                            <?php echo htmlspecialchars($tag['name']); ?>
-                                        </option>
-                                    <?php endforeach; ?>
-                                <?php endif; ?>
-                            </select>
-                            <div class="form-text">Vous pouvez sélectionner plusieurs tags en maintenant la touche Ctrl (ou Cmd sur Mac).</div>
+                            <label for="tags-input" class="form-label">Tags</label>
+                            <input id="tags-input" class="form-control" placeholder="Choisissez des tags">
+                            <div id="selected-tags"></div>
+                            <div class="form-text">Commencez à taper pour rechercher des tags existants.</div>
                         </div>
 
                         <div class="form-group">
@@ -298,6 +291,38 @@ function toggleFormatHelp() {
         helpPanel.style.display = 'none';
     }
 }
+
+document.addEventListener('DOMContentLoaded', function () {
+    const tagInput = document.getElementById('tags-input');
+    if (tagInput) {
+        const tagData = <?php echo json_encode($tags); ?>;
+        const selected = <?php echo json_encode($selected_tag_ids); ?>;
+        const tagify = new Tagify(tagInput, {
+            whitelist: tagData.map(t => ({ value: t.id, name: t.name })),
+            enforceWhitelist: true,
+            tagTextProp: 'name',
+            dropdown: { enabled: 0, maxItems: 20 }
+        });
+
+        const preselect = tagData.filter(t => selected.includes(t.id)).map(t => ({ value: t.id, name: t.name }));
+        tagify.addTags(preselect);
+
+        const container = document.getElementById('selected-tags');
+        function updateHidden() {
+            container.innerHTML = '';
+            tagify.value.forEach(tag => {
+                const hidden = document.createElement('input');
+                hidden.type = 'hidden';
+                hidden.name = 'tags[]';
+                hidden.value = tag.value;
+                container.appendChild(hidden);
+            });
+        }
+        tagify.on('add', updateHidden);
+        tagify.on('remove', updateHidden);
+        updateHidden();
+    }
+});
 </script>
 
 <?php include 'footer.php'; ?>

--- a/new-article.php
+++ b/new-article.php
@@ -189,15 +189,10 @@ code sur plusieurs lignes
                         </div>
                         
                         <div class="form-group">
-                            <label for="tags" class="form-label">Tags</label>
-                            <select id="tags" name="tags[]" class="form-control" multiple required>
-                                <?php if (!empty($tags)): ?>
-                                    <?php foreach ($tags as $tag): ?>
-                                        <option value="<?php echo $tag['id']; ?>"><?php echo htmlspecialchars($tag['name']); ?></option>
-                                    <?php endforeach; ?>
-                                <?php endif; ?>
-                            </select>
-                            <div class="form-text">Vous pouvez sélectionner plusieurs tags en maintenant la touche Ctrl (ou Cmd sur Mac).</div>
+                            <label for="tags-input" class="form-label">Tags</label>
+                            <input id="tags-input" class="form-control" placeholder="Choisissez des tags">
+                            <div id="selected-tags"></div>
+                            <div class="form-text">Commencez à taper pour rechercher ou ajouter un tag.</div>
                         </div>
 
                         <div class="form-group">
@@ -240,6 +235,33 @@ function toggleFormatHelp() {
         helpPanel.style.display = 'none';
     }
 }
+
+document.addEventListener('DOMContentLoaded', function () {
+    const tagInput = document.getElementById('tags-input');
+    if (tagInput) {
+        const tagData = <?php echo json_encode($tags); ?>;
+        const tagify = new Tagify(tagInput, {
+            whitelist: tagData.map(t => ({ value: t.id, name: t.name })),
+            enforceWhitelist: true,
+            tagTextProp: 'name',
+            dropdown: { enabled: 0, maxItems: 20 }
+        });
+
+        const container = document.getElementById('selected-tags');
+        function updateHidden() {
+            container.innerHTML = '';
+            tagify.value.forEach(tag => {
+                const hidden = document.createElement('input');
+                hidden.type = 'hidden';
+                hidden.name = 'tags[]';
+                hidden.value = tag.value;
+                container.appendChild(hidden);
+            });
+        }
+        tagify.on('add', updateHidden);
+        tagify.on('remove', updateHidden);
+    }
+});
 </script>
 
 <?php include 'footer.php'; ?>

--- a/views/templates/footer.php
+++ b/views/templates/footer.php
@@ -46,6 +46,7 @@
     </footer>
 
     <!-- JavaScript -->
+    <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify"></script>
     <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/views/templates/header.php
+++ b/views/templates/header.php
@@ -21,6 +21,8 @@ global $api;
     <link rel="stylesheet" href="assets/css/styles.css">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Tagify -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.css">
 </head>
 <body>
     <!-- Header -->


### PR DESCRIPTION
## Summary
- integrate Tagify library for better tag UX
- refactor article creation/edit forms to use Tagify input

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686fda7927a483329bc5f852867f9a14