### PR TITLE
Fix tag dropdown to display names

### DIFF
--- a/edit-article.php
+++ b/edit-article.php
@@ -301,7 +301,12 @@ document.addEventListener('DOMContentLoaded', function () {
             whitelist: tagData.map(t => ({ value: t.id, name: t.name })),
             enforceWhitelist: true,
             tagTextProp: 'name',
-            dropdown: { enabled: 0, maxItems: 20 }
+            dropdown: {
+                enabled: 0,
+                maxItems: 20,
+                mapValueTo: 'name',
+                searchKeys: ['name']
+            }
         });
 
         const preselect = tagData.filter(t => selected.includes(t.id)).map(t => ({ value: t.id, name: t.name }));

--- a/new-article.php
+++ b/new-article.php
@@ -244,7 +244,12 @@ document.addEventListener('DOMContentLoaded', function () {
             whitelist: tagData.map(t => ({ value: t.id, name: t.name })),
             enforceWhitelist: true,
             tagTextProp: 'name',
-            dropdown: { enabled: 0, maxItems: 20 }
+            dropdown: {
+                enabled: 0,
+                maxItems: 20,
+                mapValueTo: 'name',
+                searchKeys: ['name']
+            }
         });
 
         const container = document.getElementById('selected-tags');


### PR DESCRIPTION
## Summary
- show tag names instead of IDs in article forms

## Testing
- `php -l new-article.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdf7b76c08332994c78042f73e64f