### PR TITLE
Add debugging display of tags array on article page

### DIFF
--- a/views/article.php
+++ b/views/article.php
@@ -49,6 +49,12 @@
             <div class="article-content">
                 <?php echo $article['content']; // We assume this is sanitized by the API ?>
             </div>
+
+            <?php if (isset($article['tags'])): ?>
+                <pre class="debug-tags">
+<?php echo htmlspecialchars(print_r($article['tags'], true)); ?>
+                </pre>
+            <?php endif; ?>
             
             <div class="article-footer">
                 <div class="article-tags">


### PR DESCRIPTION
## Summary
- show raw `tags` array in `views/article.php` for debugging

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe8461ea083328d8b4a6203ddf23c