### PR TITLE
Add endpoint to list user threads

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -107,6 +107,17 @@ curl -X PUT -H "Content-Type: application/json" \
      http://localhost:8000/users/1/profile
 ```
 
+### GET /users/{id}/threads
+Lister les fils de discussion créés par un utilisateur.
+
+Parametres query :
+- `skip` (defaut 0)
+- `limit` (defaut 10)
+
+```bash
+curl "http://localhost:8000/users/1/threads?skip=0&limit=10"
+```
+
 ## Articles
 Revoque le token present dans l'en-tete `Authorization`.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The API will be available on port **8000** of the container. Replace
 - `GET /users/{id}` – retrieve a user
 - `GET /users` – list users
 - `GET /users/count` – total number of users
+- `GET /users/{id}/threads` – list an author's threads
 - `PUT/PATCH /users/{id}` – update account information *(requires token)*
 - `PUT/PATCH /users/{id}/bio` – update your bio *(requires token)*
 - `POST /login` – obtain a JWT access token

--- a/backend/main.py
+++ b/backend/main.py
@@ -217,6 +217,25 @@ def update_profile(user_id: int, data: schemas.UserProfileUpdate, db: Session = 
     return profile
 
 
+@app.get("/users/{user_id}/threads", response_model=List[schemas.ForumThreadOut])
+def list_user_threads(
+    user_id: int,
+    skip: int = 0,
+    limit: int = 10,
+    db: Session = Depends(get_db),
+):
+    """List forum threads created by a specific user."""
+    if not db.query(models.User).get(user_id):
+        raise HTTPException(status_code=404, detail="User not found")
+    return (
+        db.query(models.ForumThread)
+        .filter(models.ForumThread.user_id == user_id)
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
 @app.post("/articles", response_model=schemas.ArticleOut)
 def create_article(
     article: schemas.ArticleCreate,


### PR DESCRIPTION
## Summary
- allow listing a user's forum threads via `/users/{id}/threads`
- document the new endpoint in API_DEV_GUIDE
- mention the endpoint in README

## Testing
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_686fe9dc00848332ab3f5bbef4e7ab15