### PR TITLE
Implement user account deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The API will be available on port **8000** of the container. Replace
 - `GET /users/{id}/articles` – list an author's articles
 - `PUT/PATCH /users/{id}` – update account information *(requires token)*
 - `PUT/PATCH /users/{id}/bio` – update your bio *(requires token)*
+- `DELETE /users/{id}` – delete a user account *(requires token)*
 - `POST /login` – obtain a JWT access token
 - `POST /logout` – revoke the current token
 - `POST /articles` – create an article *(requires token)*

--- a/backend/main.py
+++ b/backend/main.py
@@ -85,6 +85,21 @@ def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
     return db_user
 
 
+@app.delete("/users/{user_id}", status_code=204)
+def delete_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Not authorized to delete this user")
+    db_user = db.query(models.User).get(user_id)
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    db.delete(db_user)
+    db.commit()
+
+
 @app.post("/login")
 def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
     user = db.query(models.User).filter(models.User.username == form_data.username).first()


### PR DESCRIPTION
## Summary
- allow users to delete their own accounts via `/users/{id}`
- document the new `DELETE /users/{id}` endpoint in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ff1e2282083328a20f254a592b037