### PR TITLE
Fix hero join button color

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -381,10 +381,10 @@ pre code {
   gap: 1rem;
 }
 .hero .btn-primary {
-  background-color: var(--dark-blue);
+  background-color: var(--bright-blue);
 }
 .hero .btn-primary:hover {
-  background-color: var(--dark-blue);
+  background-color: var(--light-blue);
 }
 
 /* Forum Components */


### PR DESCRIPTION
## Summary
- set hero section primary button color back to bright blue

## Testing
- `grep -n "hero .btn-primary" -n assets/css/styles.css`

------
https://chatgpt.com/codex/tasks/task_e_686ff98bc0688332b406fbaf5769f192