### PR TITLE
Handle article images and multiple tags

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -195,8 +195,10 @@ Creer un nouvel article.
 Corps JSON :
 - `title`
 - `content`
+- `image_url` (optionnel)
 - `user_id` (optionnel)
 - `is_pub` (bool, defaut `false`)
+- `tag_ids` ou `tag_names` (listes optionnelles)
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \
@@ -228,7 +230,7 @@ Modifier un article.
 
 ```bash
 curl -X PATCH -H "Content-Type: application/json" \
-     -d '{"title":"Nouveau titre"}' \
+     -d '{"title":"Nouveau titre", "image_url":"https://...", "tag_names":["news"]}' \
      http://localhost:8000/articles/1
 ```
 

--- a/api_test.py
+++ b/api_test.py
@@ -45,7 +45,9 @@ def main():
         article_payload = {
             "user_id": user_id,
             "title": "Article de test",
-            "content": "Ceci est un article factice créé automatiquement pour la vitrine."
+            "content": "Ceci est un article factice créé automatiquement pour la vitrine.",
+            "image_url": "https://example.com/test.png",
+            "tag_names": ["demo"]
         }
         resp = requests.post(f"{BASE_URL}/articles", json=article_payload, headers=headers)
         print_result("Create article", resp)

--- a/backend/main.py
+++ b/backend/main.py
@@ -275,20 +275,22 @@ def create_article(
     current_user: models.User = Depends(get_current_user),
 ):
     data = article.dict()
-    tag_id = data.pop("tag_id", None)
-    tag_name = data.pop("tag_name", None)
+    tag_ids = data.pop("tag_ids", None) or []
+    tag_names = data.pop("tag_names", None) or []
     db_article = models.Article(**data)
     db.add(db_article)
     db.commit()
-    if tag_name:
-        tag = db.query(models.Tag).filter(models.Tag.name == tag_name).first()
+    tags_to_add = set(tag_ids)
+    for name in tag_names:
+        tag = db.query(models.Tag).filter(models.Tag.name == name).first()
         if not tag:
-            tag = models.Tag(name=tag_name)
+            tag = models.Tag(name=name)
             db.add(tag)
             db.commit()
-        tag_id = tag.id
-    if tag_id:
-        db.add(models.ArticleTag(article_id=db_article.id, tag_id=tag_id))
+        tags_to_add.add(tag.id)
+    for t_id in tags_to_add:
+        db.add(models.ArticleTag(article_id=db_article.id, tag_id=t_id))
+    if tags_to_add:
         db.commit()
     db.refresh(db_article)
     return db_article
@@ -350,21 +352,24 @@ def update_article(
     if not db_article:
         raise HTTPException(status_code=404, detail="Article not found")
     data = article.dict(exclude_unset=True)
-    tag_id = data.pop("tag_id", None)
-    tag_name = data.pop("tag_name", None)
+    tag_ids = data.pop("tag_ids", None)
+    tag_names = data.pop("tag_names", None)
     for key, value in data.items():
         setattr(db_article, key, value)
-    if tag_name:
-        tag = db.query(models.Tag).filter(models.Tag.name == tag_name).first()
-        if not tag:
-            tag = models.Tag(name=tag_name)
-            db.add(tag)
-            db.commit()
-        tag_id = tag.id
-    if tag_id is not None:
+    tags_specified = tag_ids is not None or tag_names is not None
+    tags_to_set = set(tag_ids or [])
+    if tag_names:
+        for name in tag_names:
+            tag = db.query(models.Tag).filter(models.Tag.name == name).first()
+            if not tag:
+                tag = models.Tag(name=name)
+                db.add(tag)
+                db.commit()
+            tags_to_set.add(tag.id)
+    if tags_specified:
         db.query(models.ArticleTag).filter(models.ArticleTag.article_id == article_id).delete()
-        if tag_id:
-            db.add(models.ArticleTag(article_id=article_id, tag_id=tag_id))
+        for t_id in tags_to_set:
+            db.add(models.ArticleTag(article_id=article_id, tag_id=t_id))
     db.commit()
     db.refresh(db_article)
     return db_article

--- a/backend/models.py
+++ b/backend/models.py
@@ -97,6 +97,7 @@ class Article(Base):
     user_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'))
     title = Column(String(255), nullable=False)
     content = Column(Text, nullable=False)
+    image_url = Column(Text)
     is_pub = Column(Boolean, default=False)
     created_at = Column(DateTime, server_default=func.now())
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
@@ -106,8 +107,8 @@ class Article(Base):
     article_tags = relationship('ArticleTag', back_populates='article')
 
     @property
-    def tag_id(self):
-        return self.article_tags[0].tag_id if self.article_tags else None
+    def tags(self):
+        return [at.tag_id for at in self.article_tags]
 
 
 class Tag(Base):

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -39,28 +39,30 @@ class UserBioUpdate(BaseModel):
 class ArticleBase(BaseModel):
     title: str
     content: str
+    image_url: Optional[str] = None
     is_pub: Optional[bool] = False
 
 
 class ArticleCreate(ArticleBase):
     user_id: Optional[int]
-    tag_id: Optional[int] = None
-    tag_name: Optional[str] = None
+    tag_ids: Optional[list[int]] = None
+    tag_names: Optional[list[str]] = None
 
 
 class ArticleUpdate(BaseModel):
     title: Optional[str] = None
     content: Optional[str] = None
+    image_url: Optional[str] = None
     is_pub: Optional[bool] = None
     user_id: Optional[int] = None
-    tag_id: Optional[int] = None
-    tag_name: Optional[str] = None
+    tag_ids: Optional[list[int]] = None
+    tag_names: Optional[list[str]] = None
 
 
 class ArticleOut(ArticleBase):
     id: int
     user_id: Optional[int]
-    tag_id: Optional[int] = None
+    tags: list[int] = []
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
## Summary
- support `image_url` in Article model and schemas
- allow multiple tag names/ids when creating or updating articles
- expose article tag ids in API responses
- update docs and example API test accordingly

## Testing
- `python -m py_compile backend/*.py api_test.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ff9a17cb4833299454755bf44a1cd