### PR TITLE
Enable tag linking API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The API will be available on port **8000** of the container. Replace
 - `GET /articles/{id}/comments` – list comments
 - `PUT/PATCH /comments/{id}` – edit a comment *(requires token)*
 - `DELETE /comments/{id}` – remove a comment *(requires token)*
+- `POST /tags` – create a tag
+- `GET /tags` – list available tags
+- `POST /articles/{id}/tags` – link a tag to an article *(requires token)*
+- `GET /articles?tag={id}` – filter articles by tag
 - `POST /forum/categories` – create a category *(requires token)*
 - `GET /forum/categories` – list categories
 - `POST /forum/threads` – create a thread *(requires token)*

--- a/backend/main.py
+++ b/backend/main.py
@@ -332,6 +332,34 @@ def list_tags(db: Session = Depends(get_db)):
     return db.query(models.Tag).all()
 
 
+@app.post("/articles/{article_id}/tags", response_model=schemas.ArticleTagOut)
+def add_tag_to_article(
+    article_id: int,
+    article_tag: schemas.ArticleTagCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if not db.query(models.Article).get(article_id):
+        raise HTTPException(status_code=404, detail="Article not found")
+    if not db.query(models.Tag).get(article_tag.tag_id):
+        raise HTTPException(status_code=404, detail="Tag not found")
+    existing = (
+        db.query(models.ArticleTag)
+        .filter(
+            models.ArticleTag.article_id == article_id,
+            models.ArticleTag.tag_id == article_tag.tag_id,
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=400, detail="Tag already linked")
+    db_link = models.ArticleTag(article_id=article_id, tag_id=article_tag.tag_id)
+    db.add(db_link)
+    db.commit()
+    db.refresh(db_link)
+    return db_link
+
+
 @app.get("/articles/{article_id}", response_model=schemas.ArticleOut)
 def read_article(article_id: int, db: Session = Depends(get_db)):
     article = db.query(models.Article).get(article_id)


### PR DESCRIPTION
## Summary
- expose `/articles/{article_id}/tags` to associate an existing tag with an article
- document tag endpoints in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687001e4041883328b0994774782c9d7