### PR TITLE
Improve tagging system with API guide

### DIFF
--- a/controllers/ArticlesController.php
+++ b/controllers/ArticlesController.php
@@ -8,15 +8,19 @@ class ArticlesController {
         $page_title = "Articles";
         $page_description = "Articles sur l'informatique, la cybersécurité et les technologies";
         $page = isset($_GET['page']) ? sanitize_int($_GET['page']) : 1;
-        $tag = isset($_GET['tag']) ? sanitize_string($_GET['tag']) : '';
+        $tag_id = isset($_GET['tag']) ? sanitize_int($_GET['tag']) : 0;
         $skip = ($page - 1) * 9;
         try {
             $query = '/articles?skip=' . $skip . '&limit=9';
-            if (!empty($tag)) {
-                $query .= '&tag=' . urlencode($tag);
+            if ($tag_id > 0) {
+                $query .= '&tag=' . $tag_id;
             }
             $articles_data = $this->api->request($query);
-            $total_count = $this->api->request('/articles/count' . (!empty($tag) ? '?tag=' . urlencode($tag) : ''));
+            $count_query = '/articles/count';
+            if ($tag_id > 0) {
+                $count_query .= '?tag=' . $tag_id;
+            }
+            $total_count = $this->api->request($count_query);
             $total_pages = ceil(($total_count['count'] ?? 1) / 9);
         } catch (Exception $e) {
             $_SESSION['flash_message'] = "Erreur lors du chargement des articles: " . $e->getMessage();
@@ -31,6 +35,16 @@ class ArticlesController {
         } catch (Exception $e) {
             // Si l'API des tags n'est pas disponible, on continue sans les tags
             $tags = [];
+        }
+
+        $tag_name = '';
+        if ($tag_id > 0 && !empty($tags)) {
+            foreach ($tags as $t) {
+                if ((int)$t['id'] === $tag_id) {
+                    $tag_name = $t['name'];
+                    break;
+                }
+            }
         }
 
         // Charger quelques articles récents pour la sidebar, ignorer les erreurs

--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -4,6 +4,20 @@ $page_description = "Information et discussions sur la cybersécurité, les vuln
 require_once 'functions.php';
 require_once 'header.php';
 
+// Retrieve tag id for "cybersécurité"
+$security_tag_id = null;
+try {
+    $tags_list = $api->request('/tags');
+    foreach ($tags_list as $t) {
+        if (strtolower($t['name']) === 'cybersécurité' || strtolower($t['name']) === 'cybersecurite') {
+            $security_tag_id = $t['id'];
+            break;
+        }
+    }
+} catch (Exception $e) {
+    $security_tag_id = null;
+}
+
 try {
     // Load recent articles then filter by cybersecurity keywords
     $all_articles = $api->request('/articles?limit=20');
@@ -108,7 +122,7 @@ try {
                 <section style="margin-bottom: 3rem;">
                     <div class="section-header" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
                         <h2>Articles sur la Cybersécurité</h2>
-                        <a href="articles.php?tag=cybersécurité" class="view-all">Tous les articles <i class="fas fa-arrow-right"></i></a>
+                        <a href="articles.php?tag=<?php echo $security_tag_id !== null ? $security_tag_id : urlencode('cybersécurité'); ?>" class="view-all">Tous les articles <i class="fas fa-arrow-right"></i></a>
                     </div>
                     
                     <?php if (!empty($security_articles)): ?>

--- a/dev.php
+++ b/dev.php
@@ -4,6 +4,20 @@ $page_description = "Ressources, articles et discussions sur le développement i
 require_once 'functions.php';
 require_once 'header.php';
 
+// Retrieve tag id for "développement"
+$dev_tag_id = null;
+try {
+    $tags_list = $api->request('/tags');
+    foreach ($tags_list as $t) {
+        if (strtolower($t['name']) === 'développement') {
+            $dev_tag_id = $t['id'];
+            break;
+        }
+    }
+} catch (Exception $e) {
+    $dev_tag_id = null;
+}
+
 try {
     // Load recent articles then filter by development keywords
     $all_articles = $api->request('/articles?limit=20');
@@ -113,7 +127,7 @@ console.table(users, ['name', 'role']);</code></pre>
                 <section style="margin-bottom: 3rem;">
                     <div class="section-header" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
                         <h2>Articles sur le développement</h2>
-                        <a href="articles.php?tag=développement" class="view-all">Tous les articles <i class="fas fa-arrow-right"></i></a>
+                        <a href="articles.php?tag=<?php echo $dev_tag_id !== null ? $dev_tag_id : urlencode('développement'); ?>" class="view-all">Tous les articles <i class="fas fa-arrow-right"></i></a>
                     </div>
                     
                     <?php if (!empty($dev_articles)): ?>

--- a/edit-article.php
+++ b/edit-article.php
@@ -83,12 +83,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_toke
             }
 
             // Handle tag update
-            if (!empty($new_tag)) {
-                $article_data['tag_name'] = $new_tag;
-            } elseif (!empty($selected_tags)) {
-                $article_data['tag_id'] = $selected_tags[0];
+            if (!empty($selected_tags)) {
+                $article_data['tag_ids'] = $selected_tags;
             } else {
-                $article_data['tag_id'] = null;
+                $article_data['tag_ids'] = [];
+            }
+            if (!empty($new_tag)) {
+                $article_data['tag_names'] = [$new_tag];
             }
 
             $api->request('/articles/' . $article_id, 'PATCH', $article_data, true);

--- a/new-article.php
+++ b/new-article.php
@@ -52,11 +52,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_toke
                 'user_id' => $user['id'] ?? null
             ];
 
-            // Associate tag with the article
+            // Associate tags with the article
+            if (!empty($selected_tags)) {
+                $article_data['tag_ids'] = $selected_tags;
+            }
             if (!empty($new_tag)) {
-                $article_data['tag_name'] = $new_tag;
-            } elseif (!empty($selected_tags)) {
-                $article_data['tag_id'] = $selected_tags[0];
+                $article_data['tag_names'] = [$new_tag];
             }
 
             $result = $api->request('/articles', 'POST', $article_data, true);

--- a/profile.php
+++ b/profile.php
@@ -200,7 +200,7 @@ include 'header.php';
                                                         <?php if (isset($article['tags']) && !empty($article['tags'])): ?>
                                                             • 
                                                             <?php foreach ($article['tags'] as $index => $tag): ?>
-                                                                <a href="articles.php?tag=<?php echo urlencode($tag['name']); ?>" style="color: var(--bright-blue);">
+                                                                <a href="articles.php?tag=<?php echo $tag['id']; ?>" style="color: var(--bright-blue);">
                                                                     #<?php echo htmlspecialchars($tag['name']); ?>
                                                                 </a>
                                                                 <?php if ($index < count($article['tags']) - 1) echo ', '; ?>

--- a/search.php
+++ b/search.php
@@ -164,7 +164,7 @@ function highlightSearchTerms($text, $search) {
                                             &bull;
                                             <span>
                                                 <?php foreach ($article['tags'] as $index => $tag): ?>
-                                                    <a href="articles.php?tag=<?php echo urlencode($tag['name']); ?>" class="article-tag" style="font-size: 0.75rem; background-color: var(--light-gray); padding: 0.1rem 0.5rem; border-radius: 10px;"><?php echo htmlspecialchars($tag['name']); ?></a>
+                                                    <a href="articles.php?tag=<?php echo $tag['id']; ?>" class="article-tag" style="font-size: 0.75rem; background-color: var(--light-gray); padding: 0.1rem 0.5rem; border-radius: 10px;"><?php echo htmlspecialchars($tag['name']); ?></a>
                                                     <?php if ($index < count($article['tags']) - 1) echo ' '; ?>
                                                 <?php endforeach; ?>
                                             </span>

--- a/views/article.php
+++ b/views/article.php
@@ -38,7 +38,7 @@
                 <?php if (isset($article['tags']) && !empty($article['tags'])): ?>
                     <div class="article-tags" style="margin-top: 1rem;">
                         <?php foreach ($article['tags'] as $tag): ?>
-                            <a href="articles.php?tag=<?php echo urlencode($tag['name']); ?>" class="article-tag">
+                            <a href="articles.php?tag=<?php echo $tag['id']; ?>" class="article-tag">
                                 <?php echo htmlspecialchars($tag['name']); ?>
                             </a>
                         <?php endforeach; ?>
@@ -60,7 +60,7 @@
                 <div class="article-tags">
                     <?php if (isset($article['tags']) && !empty($article['tags'])): ?>
                         <?php foreach ($article['tags'] as $tag): ?>
-                            <a href="articles.php?tag=<?php echo urlencode($tag['name']); ?>" class="article-tag">
+                            <a href="articles.php?tag=<?php echo $tag['id']; ?>" class="article-tag">
                                 <?php echo htmlspecialchars($tag['name']); ?>
                             </a>
                         <?php endforeach; ?>

--- a/views/articles.php
+++ b/views/articles.php
@@ -4,8 +4,8 @@
     <div class="container">
         <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
             <a href="index.php" style="color: #999;">Accueil</a> &raquo; Articles
-            <?php if (!empty($tag)): ?>
-                &raquo; Tag: <?php echo htmlspecialchars($tag); ?>
+            <?php if (!empty($tag_name)): ?>
+                &raquo; Tag: <?php echo htmlspecialchars($tag_name); ?>
             <?php endif; ?>
         </div>
         <h1 style="color: var(--white); margin-bottom: 0.5rem;">Articles</h1>
@@ -19,9 +19,9 @@
         <div class="grid grid-sidebar">
             <!-- Articles List -->
             <div class="articles-list">
-                <?php if (!empty($tag)): ?>
+                <?php if (!empty($tag_name)): ?>
                     <div style="margin-bottom: 1.5rem;">
-                        <h2>Articles avec le tag: <?php echo htmlspecialchars($tag); ?></h2>
+                        <h2>Articles avec le tag: <?php echo htmlspecialchars($tag_name); ?></h2>
             <a href="index.php?route=articles" class="btn btn-outline btn-sm">Voir tous les articles</a>
                     </div>
 
@@ -100,7 +100,7 @@
                     <?php if ($total_pages > 1): ?>
                         <div class="pagination" style="margin-top: 2rem;">
                             <?php if ($page > 1): ?>
-                                <a href="?page=<?php echo $page - 1; ?><?php echo !empty($tag) ? '&tag=' . urlencode($tag) : ''; ?>">
+                                <a href="?page=<?php echo $page - 1; ?><?php echo $tag_id > 0 ? '&tag=' . $tag_id : ''; ?>">
                                     <i class="fas fa-chevron-left"></i> Précédent
                                 </a>
                             <?php endif; ?>
@@ -109,14 +109,14 @@
                                 <?php if ($i == $page): ?>
                                     <span class="current"><?php echo $i; ?></span>
                                 <?php else: ?>
-                                    <a href="?page=<?php echo $i; ?><?php echo !empty($tag) ? '&tag=' . urlencode($tag) : ''; ?>">
+                                    <a href="?page=<?php echo $i; ?><?php echo $tag_id > 0 ? '&tag=' . $tag_id : ''; ?>">
                                         <?php echo $i; ?>
                                     </a>
                                 <?php endif; ?>
                             <?php endfor; ?>
                             
                             <?php if ($page < $total_pages): ?>
-                                <a href="?page=<?php echo $page + 1; ?><?php echo !empty($tag) ? '&tag=' . urlencode($tag) : ''; ?>">
+                                <a href="?page=<?php echo $page + 1; ?><?php echo $tag_id > 0 ? '&tag=' . $tag_id : ''; ?>">
                                     Suivant <i class="fas fa-chevron-right"></i>
                 
                                 </a>
@@ -156,7 +156,7 @@
                     <div class="widget-content">
                         <div class="article-tags">
                             <?php foreach ($tags as $t): ?>
-                                <a href="index.php?route=articles&amp;tag=<?php echo urlencode($t['name']); ?>" class="article-tag">
+                                <a href="index.php?route=articles&amp;tag=<?php echo $t['id']; ?>" class="article-tag">
                                     <?php echo htmlspecialchars($t['name']); ?>
                                 </a>
                             <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- support multiple tags when creating or editing articles
- use tag IDs for filtering and display
- resolve tag names from `/tags` list
- link tags by ID across pages

## Testing
- `php` syntax check *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870077a5cd88332904f690f1698671f