### PR TITLE
Améliore affichage des tags d'articles

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -627,13 +627,23 @@ pre code {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  margin-top: 0.5rem;
 }
 
 .article-tag {
+  display: inline-block;
   background-color: var(--light-gray);
+  color: var(--dark-blue);
   padding: 0.25rem 0.75rem;
-  border-radius: 20px;
+  border-radius: 15px;
   font-size: 0.75rem;
+  text-decoration: none;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.article-tag:hover {
+  background-color: var(--bright-blue);
+  color: var(--white);
 }
 
 .article-actions {

--- a/assets_css_styles.css
+++ b/assets_css_styles.css
@@ -607,13 +607,23 @@ pre code {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  margin-top: 0.5rem;
 }
 
 .article-tag {
+  display: inline-block;
   background-color: var(--light-gray);
+  color: var(--dark-blue);
   padding: 0.25rem 0.75rem;
-  border-radius: 20px;
+  border-radius: 15px;
   font-size: 0.75rem;
+  text-decoration: none;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.article-tag:hover {
+  background-color: var(--bright-blue);
+  color: var(--white);
 }
 
 .article-actions {

--- a/views/article.php
+++ b/views/article.php
@@ -50,23 +50,19 @@
                 <?php echo $article['content']; // We assume this is sanitized by the API ?>
             </div>
 
-            <?php if (isset($article['tags'])): ?>
-                <pre class="debug-tags">
-<?php echo htmlspecialchars(print_r($article['tags'], true)); ?>
-                </pre>
-            <?php endif; ?>
             
             <div class="article-footer">
-                <div class="article-tags">
-                    <?php if (isset($article['tags']) && !empty($article['tags'])): ?>
-                        <?php foreach ($article['tags'] as $tag): ?>
-                            <a href="articles.php?tag=<?php echo $tag['id']; ?>" class="article-tag">
-                                <?php echo htmlspecialchars($tag['name']); ?>
-                            </a>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
+                <?php if (isset($article['tags']) && !empty($article['tags'])): ?>
+                <div class="article-tags" style="margin-bottom: 1rem;">
+                    <strong style="margin-right:0.25rem;">Tags:</strong>
+                    <?php foreach ($article['tags'] as $tag): ?>
+                        <a href="articles.php?tag=<?php echo $tag['id']; ?>" class="article-tag">
+                            <?php echo htmlspecialchars($tag['name']); ?>
+                        </a>
+                    <?php endforeach; ?>
                 </div>
-                
+                <?php endif; ?>
+
                 <div class="article-actions">
                     <?php if ($api->isLoggedIn()): ?>
                         <button type="button" class="btn btn-outline btn-sm" onclick="likeArticle(<?php echo $article_id; ?>)">
@@ -82,9 +78,9 @@
                                 <i class="fas fa-edit"></i> Éditer
                             </a>
                         <?php endif; ?>
-                    <?php endif; ?>
-                    </div>
+                        <?php endif; ?>
                 </div>
+            </div>
             </article>
             </div>
             <aside class="sidebar">


### PR DESCRIPTION
## Summary
- enlève le bloc `<pre>` de debug
- ajoute un bloc ergonomique pour les tags dans la vue article
- améliore le style `.article-tag` avec survol et couleurs

## Testing
- `php -l views/article.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700cc788088332abc9c954c78688db