### PR TITLE
Improve topic detection for dev/cyber pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -31,13 +31,17 @@ function verify_csrf_token($token) {
  * @return string|null
  */
 function detect_topic(array $tags = [], string $content = '') {
+    // Expanded keyword lists for more reliable matching
     $dev_keywords = [
-        'dev', 'développement', 'programmation', 'code', 'framework', 'web',
-        'mobile', 'ia', 'devops'
+        'dev', 'développement', 'developpement', 'development', 'développeur',
+        'developpeur', 'developer', 'programmation', 'coding', 'code',
+        'framework', 'web', 'mobile', 'ia', 'devops'
     ];
     $security_keywords = [
-        'cyber', 'sécurité', 'securite', 'hacking', 'pentest', 'vuln',
-        'vulnérabilité', 'vulnerabilite', 'cryptographie', 'protection des données'
+        'cyber', 'cybersécurité', 'cybersecurite', 'cyber sécurité',
+        'cybersecurity', 'sécurité', 'securite', 'hacking', 'pentest', 'vuln',
+        'vulnérabilité', 'vulnerabilite', 'cryptographie', 'malware',
+        'protection des données', 'attaque', 'intrusion', 'ransomware'
     ];
 
     $text = strtolower($content . ' ' . implode(' ', $tags));


### PR DESCRIPTION
## Summary
- expand keywords used by `detect_topic`

## Testing
- `php -l functions.php`
- `php -r "require 'functions.php'; echo detect_topic([], 'This is about cybersecurity and hacking');"`
- `php -r "require 'functions.php'; echo detect_topic([], 'Mon article sur le developpement web');"`
- `php -r "require 'functions.php'; echo detect_topic([], 'discussion sur le ransomware et la securite');"`


------
https://chatgpt.com/codex/tasks/task_e_68700db7142c8332a5aabc67869c6d7b