### PR TITLE
Remove undefined API calls

### DIFF
--- a/profile.php
+++ b/profile.php
@@ -29,12 +29,10 @@ try {
     $article_count = is_array($user_articles) ? count($user_articles) : 0;
     $recent_articles = array_slice($user_articles, 0, 5);
 
-    // Replies count (optional endpoint)
-    try {
-        $user_replies = $api->request('/users/' . $user_id . '/replies', 'GET', [], true);
-        $reply_count = is_array($user_replies) ? count($user_replies) : 0;
-    } catch (Exception $e) {
-        $reply_count = $profile['reply_count'] ?? 0;
+    // Replies count computed from thread data
+    $reply_count = 0;
+    foreach ($user_threads as $t) {
+        $reply_count += $t['reply_count'] ?? 0;
     }
 
     $page_title = $profile['username'] . " - Profil";

--- a/search.php
+++ b/search.php
@@ -26,39 +26,30 @@ $total_pages = 1;
 // Execute search if query provided
 if (!empty($q)) {
     try {
-        // Build search query
-        $search_query = '/search?q=' . urlencode($q) . '&skip=' . $skip . '&limit=' . $limit;
-        
+        // Build search query for all results and count locally
+        $search_query = '/search?q=' . urlencode($q) . '&limit=1000';
         if ($type !== 'all') {
             $search_query .= '&type=' . urlencode($type);
         }
-        
-        // Execute search
-        $search_results = $api->request($search_query);
-        
-        // Extract results based on type
-        if ($search_articles && isset($search_results['articles'])) {
-            $articles = $search_results['articles'];
+
+        $all_results = $api->request($search_query);
+
+        if ($search_articles && isset($all_results['articles'])) {
+            $articles = array_slice($all_results['articles'], $skip, $limit);
+            $total_results += count($all_results['articles']);
         }
-        
-        if ($search_threads && isset($search_results['threads'])) {
-            $threads = $search_results['threads'];
+
+        if ($search_threads && isset($all_results['threads'])) {
+            $threads = array_slice($all_results['threads'], $skip, $limit);
+            $total_results += count($all_results['threads']);
         }
-        
-        if ($search_users && isset($search_results['users'])) {
-            $users = $search_results['users'];
+
+        if ($search_users && isset($all_results['users'])) {
+            $users = array_slice($all_results['users'], $skip, $limit);
+            $total_results += count($all_results['users']);
         }
-        
-        // Get total count for pagination
-        $total_count_query = '/search/count?q=' . urlencode($q);
-        if ($type !== 'all') {
-            $total_count_query .= '&type=' . urlencode($type);
-        }
-        
-        $count_result = $api->request($total_count_query);
-        $total_results = $count_result['count'] ?? 0;
-        $total_pages = ceil($total_results / $limit);
-        
+
+        $total_pages = max(1, ceil($total_results / $limit));
     } catch (Exception $e) {
         $_SESSION['flash_message'] = "Erreur lors de la recherche: " . $e->getMessage();
         $_SESSION['flash_type'] = "error";

--- a/thread.php
+++ b/thread.php
@@ -107,12 +107,7 @@ try {
         }
     }
 
-    // Update view count but continue even if the endpoint does not exist
-    try {
-        $api->request('/forum/threads/' . $thread_id . '/view', 'POST');
-    } catch (Exception $e) {
-        // Ignore missing view tracking endpoint
-    }
+
     
     $page_title = $thread['title'];
     $page_description = substr(strip_tags($thread['content']), 0, 160);


### PR DESCRIPTION
## Summary
- stop calling nonexistent replies and search count endpoints
- compute reply totals using user threads
- compute search result totals client side
- drop unused thread view call

## Testing
- `php -l search.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700f5e2c9c83329cc44b6209e7ce4e