### PR TITLE
Fix article deletion cascade

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -103,8 +103,18 @@ class Article(Base):
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
 
     author = relationship('User', back_populates='articles')
-    comments = relationship('Comment', back_populates='article')
-    article_tags = relationship('ArticleTag', back_populates='article')
+    comments = relationship(
+        'Comment',
+        back_populates='article',
+        cascade='all, delete-orphan',
+        passive_deletes=True,
+    )
+    article_tags = relationship(
+        'ArticleTag',
+        back_populates='article',
+        cascade='all, delete-orphan',
+        passive_deletes=True,
+    )
 
     @property
     def tags(self):


### PR DESCRIPTION
## Summary
- fix cascade delete for comments and article tags on article deletion

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68701e18c7588332acbee08a622e0724