### PR TITLE
Filter dev and security articles by tag

### DIFF
--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -19,16 +19,21 @@ try {
 }
 
 try {
-    // Load recent articles then filter by cybersecurity keywords
-    $all_articles = $api->request('/articles?limit=20');
-    $security_articles = [];
-    foreach ($all_articles as $article) {
-        $tags = array_column($article['tags'] ?? [], 'name');
-        if (detect_topic($tags, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'security') {
-            $security_articles[] = $article;
-        }
-        if (count($security_articles) >= 6) {
-            break;
+    // Fetch articles using the security tag when available
+    if ($security_tag_id !== null) {
+        $security_articles = $api->request('/articles?tag=' . $security_tag_id . '&limit=6');
+    } else {
+        // Fallback to keyword detection on recent articles
+        $all_articles = $api->request('/articles?limit=20');
+        $security_articles = [];
+        foreach ($all_articles as $article) {
+            $tags = array_column($article['tags'] ?? [], 'name');
+            if (detect_topic($tags, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'security') {
+                $security_articles[] = $article;
+            }
+            if (count($security_articles) >= 6) {
+                break;
+            }
         }
     }
 

--- a/dev.php
+++ b/dev.php
@@ -19,16 +19,21 @@ try {
 }
 
 try {
-    // Load recent articles then filter by development keywords
-    $all_articles = $api->request('/articles?limit=20');
-    $dev_articles = [];
-    foreach ($all_articles as $article) {
-        $tags = array_column($article['tags'] ?? [], 'name');
-        if (detect_topic($tags, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'dev') {
-            $dev_articles[] = $article;
-        }
-        if (count($dev_articles) >= 6) {
-            break;
+    // Fetch articles using the development tag when available
+    if ($dev_tag_id !== null) {
+        $dev_articles = $api->request('/articles?tag=' . $dev_tag_id . '&limit=6');
+    } else {
+        // Fallback to keyword detection on recent articles
+        $all_articles = $api->request('/articles?limit=20');
+        $dev_articles = [];
+        foreach ($all_articles as $article) {
+            $tags = array_column($article['tags'] ?? [], 'name');
+            if (detect_topic($tags, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'dev') {
+                $dev_articles[] = $article;
+            }
+            if (count($dev_articles) >= 6) {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- query articles for `cyber-securite.php` and `dev.php` by tag when the tag exists
- fall back to existing keyword detection if tag lookups fail

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6870252a3ba883329880498732af52c6