### PR TITLE
Add reporting config endpoint

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -347,5 +347,12 @@ Supprimer une réponse *(token requis)*.
 curl -H "Authorization: Bearer <TOKEN>" -X DELETE http://localhost:8000/forum/replies/3
 ```
 
+### GET /reporting/config
+Récupérer la configuration des signalements.
+
+```bash
+curl http://localhost:8000/reporting/config
+```
+
 ---
 Ce guide reprend tous les points d'entrée actuellement implémentés dans l'API. Les schémas Pydantic sont disponibles dans `backend/schemas.py` pour plus de détails sur les champs acceptés.

--- a/backend/main.py
+++ b/backend/main.py
@@ -595,3 +595,15 @@ def delete_reply(
         raise HTTPException(status_code=404, detail="Reply not found")
     db.delete(db_reply)
     db.commit()
+
+
+@app.get("/reporting/config", response_model=schemas.ReportingConfigOut)
+def get_reporting_config(db: Session = Depends(get_db)):
+    config = (
+        db.query(models.ReportingConfig)
+        .order_by(models.ReportingConfig.id.desc())
+        .first()
+    )
+    if not config:
+        raise HTTPException(status_code=404, detail="Config not found")
+    return config

--- a/backend/models.py
+++ b/backend/models.py
@@ -341,3 +341,12 @@ class Setting(Base):
     key = Column(String(100), primary_key=True)
     value = Column(Text)
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+
+class ReportingConfig(Base):
+    __tablename__ = 'reporting_config'
+
+    id = Column(Integer, primary_key=True, index=True)
+    discord_webhook = Column(Text, nullable=False)
+    ntfy_topic = Column(Text, nullable=False)
+    created_at = Column(DateTime, server_default=func.now())

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -378,3 +378,13 @@ class PermissionUpdate(BaseModel):
 
 class UserRoleAssign(BaseModel):
     role_id: int
+
+
+class ReportingConfigOut(BaseModel):
+    id: int
+    discord_webhook: str
+    ntfy_topic: str
+    created_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- map `reporting_config` table in SQLAlchemy models
- add `ReportingConfigOut` Pydantic schema
- implement `/reporting/config` route returning the latest configuration
- document this new endpoint in the API development guide

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687029bbaef4833298ec2bba5f0ccee6