### PR TITLE
Display usernames for posts

### DIFF
--- a/category.php
+++ b/category.php
@@ -80,7 +80,7 @@ include 'header.php';
                                     <div>par <a href="profile.php?id=<?php echo $thread['last_reply_user']['id']; ?>"><?php echo htmlspecialchars($thread['last_reply_user']['username']); ?></a></div>
                                     <div><?php echo date('d/m à H:i', strtotime($thread['last_reply_at'])); ?></div>
                                 <?php else: ?>
-                                    <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></a></div>
+                                    <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?></a></div>
                                     <div><?php echo date('d/m à H:i', strtotime($thread['created_at'])); ?></div>
                                 <?php endif; ?>
                             </div>

--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -145,7 +145,7 @@ try {
                                             <a href="article.php?id=<?php echo $article['id']; ?>"><?php echo htmlspecialchars($article['title']); ?></a>
                                         </h3>
                                         <div class="article-card-meta">
-                                            <span>Par <?php echo htmlspecialchars($article['username'] ?? 'Auteur'); ?></span> • 
+                                            <span>Par <?php echo htmlspecialchars(get_username($article) ?? 'Auteur'); ?></span> •
                                             <span><?php echo date('d/m/Y', strtotime($article['created_at'])); ?></span>
                                         </div>
                                         <p class="article-card-excerpt">
@@ -194,7 +194,7 @@ try {
                                                 <div>par <a href="profile.php?id=<?php echo $thread['last_reply_user']['id']; ?>"><?php echo htmlspecialchars($thread['last_reply_user']['username']); ?></a></div>
                                                 <div><?php echo date('d/m à H:i', strtotime($thread['last_reply_at'])); ?></div>
                                             <?php else: ?>
-                                                <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></a></div>
+                                                <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?></a></div>
                                                 <div><?php echo date('d/m à H:i', strtotime($thread['created_at'])); ?></div>
                                             <?php endif; ?>
                                         </div>

--- a/dev.php
+++ b/dev.php
@@ -150,7 +150,7 @@ console.table(users, ['name', 'role']);</code></pre>
                                             <a href="article.php?id=<?php echo $article['id']; ?>"><?php echo htmlspecialchars($article['title']); ?></a>
                                         </h3>
                                         <div class="article-card-meta">
-                                            <span>Par <?php echo htmlspecialchars($article['username'] ?? 'Auteur'); ?></span> • 
+                                            <span>Par <?php echo htmlspecialchars(get_username($article) ?? 'Auteur'); ?></span> •
                                             <span><?php echo date('d/m/Y', strtotime($article['created_at'])); ?></span>
                                         </div>
                                         <p class="article-card-excerpt">
@@ -199,7 +199,7 @@ console.table(users, ['name', 'role']);</code></pre>
                                                 <div>par <a href="profile.php?id=<?php echo $thread['last_reply_user']['id']; ?>"><?php echo htmlspecialchars($thread['last_reply_user']['username']); ?></a></div>
                                                 <div><?php echo date('d/m à H:i', strtotime($thread['last_reply_at'])); ?></div>
                                             <?php else: ?>
-                                                <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></a></div>
+                                                <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?></a></div>
                                                 <div><?php echo date('d/m à H:i', strtotime($thread['created_at'])); ?></div>
                                             <?php endif; ?>
                                         </div>

--- a/functions.php
+++ b/functions.php
@@ -121,4 +121,26 @@ function calculate_forum_stats($api) {
 
     return $stats;
 }
+
+/**
+ * Extract a username from an API entity array.
+ *
+ * Many API responses include a nested `user` or `author` object. This helper
+ * attempts to retrieve the username from the various possible keys.
+ *
+ * @param array $data Entity returned by the API
+ * @return string|null Username if available, otherwise null
+ */
+function get_username(array $data) {
+    if (!empty($data['username'])) {
+        return $data['username'];
+    }
+    if (!empty($data['author']['username'])) {
+        return $data['author']['username'];
+    }
+    if (!empty($data['user']['username'])) {
+        return $data['user']['username'];
+    }
+    return null;
+}
 ?>

--- a/search.php
+++ b/search.php
@@ -148,7 +148,7 @@ function highlightSearchTerms($text, $search) {
                                     </h3>
                                     
                                     <div class="search-meta" style="margin-bottom: 1rem; font-size: 0.875rem; color: #666;">
-                                        <span><i class="fas fa-user"></i> <?php echo htmlspecialchars($article['username'] ?? 'Auteur'); ?></span> &bull;
+                                        <span><i class="fas fa-user"></i> <?php echo htmlspecialchars(get_username($article) ?? 'Auteur'); ?></span> &bull;
                                         <span><i class="far fa-calendar"></i> <?php echo date('d/m/Y', strtotime($article['created_at'])); ?></span> &bull;
                                         
                                         <?php if (isset($article['tags']) && !empty($article['tags'])): ?>
@@ -202,7 +202,7 @@ function highlightSearchTerms($text, $search) {
                                     </h3>
                                     
                                     <div class="search-meta" style="margin-bottom: 1rem; font-size: 0.875rem; color: #666;">
-                                        <span><i class="fas fa-user"></i> <?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></span> &bull;
+                                        <span><i class="fas fa-user"></i> <?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?></span> &bull;
                                         <span><i class="far fa-calendar"></i> <?php echo date('d/m/Y', strtotime($thread['created_at'])); ?></span> &bull;
                                         <span><i class="far fa-comment"></i> <?php echo $thread['reply_count'] ?? 0; ?> réponses</span> &bull;
                                         

--- a/thread.php
+++ b/thread.php
@@ -47,7 +47,7 @@ try {
             <div class="post reply-level-<?php echo $level; ?>" id="reply-<?php echo $reply['id']; ?>">
                 <div class="post-sidebar">
                     <img src="<?php echo isset($reply['user']['avatar_url']) && !empty($reply['user']['avatar_url']) ? htmlspecialchars($reply['user']['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" class="user-avatar">
-                    <div class="user-name"><?php echo htmlspecialchars($reply['username'] ?? 'Utilisateur'); ?></div>
+                    <div class="user-name"><?php echo htmlspecialchars(get_username($reply) ?? 'Utilisateur'); ?></div>
                     <div class="user-info">
                         <?php
                         $role = isset($reply['user']['role']) ? $reply['user']['role'] : '';
@@ -80,10 +80,10 @@ try {
 
                         <div class="post-actions">
                             <?php if ($api->isLoggedIn()): ?>
-                                <button type="button" class="btn btn-outline btn-sm" onclick="quotePost(<?php echo $reply['id']; ?>, '<?php echo htmlspecialchars($reply['username'] ?? 'Utilisateur'); ?>')">
+                                <button type="button" class="btn btn-outline btn-sm" onclick="quotePost(<?php echo $reply['id']; ?>, '<?php echo htmlspecialchars(get_username($reply) ?? 'Utilisateur'); ?>')">
                                     <i class="fas fa-quote-right"></i> Citer
                                 </button>
-                                <button type="button" class="btn btn-outline btn-sm" onclick="replyTo(<?php echo $reply['id']; ?>, '<?php echo htmlspecialchars($reply['username'] ?? 'Utilisateur'); ?>')">
+                                <button type="button" class="btn btn-outline btn-sm" onclick="replyTo(<?php echo $reply['id']; ?>, '<?php echo htmlspecialchars(get_username($reply) ?? 'Utilisateur'); ?>')">
                                     <i class="fas fa-reply"></i> Répondre
                                 </button>
                                 <?php if (isset($_SESSION['user']['id']) && $_SESSION['user']['id'] === $reply['user_id']): ?>
@@ -187,7 +187,7 @@ include 'header.php';
             <div class="post">
                 <div class="post-sidebar">
                     <img src="<?php echo isset($thread['user']['avatar_url']) && !empty($thread['user']['avatar_url']) ? htmlspecialchars($thread['user']['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" class="user-avatar">
-                    <div class="user-name"><?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></div>
+                    <div class="user-name"><?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?></div>
                     <div class="user-info">
                         <?php
                         $role = isset($thread['user']['role']) ? $thread['user']['role'] : '';
@@ -212,10 +212,10 @@ include 'header.php';
                         
                         <div class="post-actions">
                             <?php if ($api->isLoggedIn()): ?>
-                                <button type="button" class="btn btn-outline btn-sm" onclick="quotePost(<?php echo $thread_id; ?>, '<?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?>')">
+                                <button type="button" class="btn btn-outline btn-sm" onclick="quotePost(<?php echo $thread_id; ?>, '<?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?>')">
                                     <i class="fas fa-quote-right"></i> Citer
                                 </button>
-                                <button type="button" class="btn btn-outline btn-sm" onclick="replyTo(0, '<?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?>')">
+                                <button type="button" class="btn btn-outline btn-sm" onclick="replyTo(0, '<?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?>')">
                                     <i class="fas fa-reply"></i> Répondre
                                 </button>
                                 

--- a/views/article.php
+++ b/views/article.php
@@ -29,7 +29,7 @@
                     <div class="article-author">
                         <img src="<?php echo isset($article['author']['avatar_url']) && !empty($article['author']['avatar_url']) ? htmlspecialchars($article['author']['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" class="article-author-avatar">
                         <div>
-                            <a href="profile.php?id=<?php echo $article['user_id']; ?>"><?php echo htmlspecialchars($article['username'] ?? 'Auteur'); ?></a>
+                            <a href="profile.php?id=<?php echo $article['user_id']; ?>"><?php echo htmlspecialchars(get_username($article) ?? 'Auteur'); ?></a>
                         </div>
                     </div>
                     <div><i class="far fa-calendar"></i> <?php echo date('d/m/Y', strtotime($article['created_at'])); ?></div>
@@ -119,7 +119,7 @@
                 <img src="<?php echo isset($comment['user']['avatar_url']) && !empty($comment['user']['avatar_url']) ? htmlspecialchars($comment['user']['avatar_url']) : DEFAULT_AVATAR_URL; ?>" alt="Avatar" class="comment-avatar">
                 <div class="comment-body">
                     <div class="comment-meta">
-                        <span class="comment-author"><a href="profile.php?id=<?php echo $comment['user_id']; ?>"><?php echo htmlspecialchars($comment['username'] ?? 'Utilisateur'); ?></a></span>
+                        <span class="comment-author"><a href="profile.php?id=<?php echo $comment['user_id']; ?>"><?php echo htmlspecialchars(get_username($comment) ?? 'Utilisateur'); ?></a></span>
                         <span><?php echo date('d/m/Y à H:i', strtotime($comment['created_at'])); ?></span>
                         <?php if (isset($comment['updated_at']) && $comment['updated_at'] !== $comment['created_at']): ?>
                             <em>(édité le <?php echo date('d/m/Y à H:i', strtotime($comment['updated_at'])); ?>)</em>

--- a/views/articles.php
+++ b/views/articles.php
@@ -79,7 +79,7 @@
                                         <a href="index.php?route=article&id=<?php echo $article['id']; ?>"><?php echo htmlspecialchars($article['title']); ?></a>
                                     </h3>
                                     <div class="article-card-meta">
-                                        <span>Par <?php echo htmlspecialchars($article['username'] ?? 'Auteur'); ?></span> • 
+                                        <span>Par <?php echo htmlspecialchars(get_username($article) ?? 'Auteur'); ?></span> •
                                         <span><?php echo date('d/m/Y', strtotime($article['created_at'])); ?></span>
                                     </div>
                                     <p class="article-card-excerpt">

--- a/views/forums.php
+++ b/views/forums.php
@@ -88,7 +88,7 @@
                                                             <div>par <a href="profile.php?id=<?php echo $thread['last_reply_user']['id']; ?>"><?php echo htmlspecialchars($thread['last_reply_user']['username']); ?></a></div>
                                                             <div><?php echo date('d/m à H:i', strtotime($thread['last_reply_at'])); ?></div>
                                                         <?php else: ?>
-                                                            <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></a></div>
+                                                            <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?></a></div>
                                                             <div><?php echo date('d/m à H:i', strtotime($thread['created_at'])); ?></div>
                                                         <?php endif; ?>
                                                     </div>
@@ -184,7 +184,7 @@
                                 <li style="padding: 0.75rem 0; border-bottom: 1px solid var(--light-gray);">
                                     <a href="thread.php?id=<?php echo $thread['id']; ?>" style="font-weight: 500;"><?php echo htmlspecialchars($thread['title']); ?></a>
                                     <div style="font-size: 0.8125rem; color: #666; margin-top: 0.25rem;">
-                                        <span>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></a></span>
+                                        <span>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?></a></span>
                                         <span style="margin-left: 0.5rem;"><?php echo date('d/m à H:i', strtotime($thread['created_at'])); ?></span>
                                     </div>
                                 </li>

--- a/views/home.php
+++ b/views/home.php
@@ -67,7 +67,7 @@
                                                         <div>par <a href="profile.php?id=<?php echo $thread['last_reply_user']['id']; ?>"><?php echo htmlspecialchars($thread['last_reply_user']['username']); ?></a></div>
                                                         <div><?php echo date('d/m à H:i', strtotime($thread['last_reply_at'])); ?></div>
                                                     <?php else: ?>
-                                                        <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars($thread['username'] ?? 'Utilisateur'); ?></a></div>
+                                                        <div>par <a href="profile.php?id=<?php echo $thread['user_id']; ?>"><?php echo htmlspecialchars(get_username($thread) ?? 'Utilisateur'); ?></a></div>
                                                         <div><?php echo date('d/m à H:i', strtotime($thread['created_at'])); ?></div>
                                                     <?php endif; ?>
                                                 </div>
@@ -141,7 +141,7 @@
                                             <a href="article.php?id=<?php echo $article['id']; ?>"><?php echo htmlspecialchars($article['title']); ?></a>
                                         </h3>
                                         <div class="article-card-meta">
-                                            <span>Par <?php echo htmlspecialchars($article['username'] ?? 'Auteur'); ?></span> •
+                                            <span>Par <?php echo htmlspecialchars(get_username($article) ?? 'Auteur'); ?></span> •
                                             <span><?php echo date('d/m/Y', strtotime($article['created_at'])); ?></span>
                                         </div>
                                         <p class="article-card-excerpt">


### PR DESCRIPTION
## Summary
- add `get_username` helper for flexible user name lookup
- use the helper when rendering articles and threads

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68702adc6cfc8332a7b3536882105dbb