### PR TITLE
Ajout pseudo utilisateur dans le header

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -208,6 +208,11 @@ pre code {
   object-fit: cover;
 }
 
+.header-username {
+  color: var(--white);
+  font-weight: 500;
+}
+
 .user-dropdown-toggle:hover {
   background-color: rgba(255, 255, 255, 0.1);
 }

--- a/views/templates/header.php
+++ b/views/templates/header.php
@@ -58,6 +58,7 @@ global $api;
                     <div class="user-dropdown">
                         <button class="user-dropdown-toggle">
                             <img src="<?php echo $avatar; ?>" alt="Avatar" class="header-avatar">
+                            <span class="header-username"><?php echo htmlspecialchars($user['username']); ?></span>
                             <i class="fas fa-chevron-down"></i>
                         </button>
                         <div class="user-dropdown-menu">


### PR DESCRIPTION
## Summary
- afficher le pseudo à côté de la photo de profil dans l'en-tête
- ajouter un style pour le pseudo dans la barre de navigation

## Testing
- `phpunit` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68702e584fc883328679689f5beba720