### PR TITLE
Fix dev & security pages when optional APIs missing

### DIFF
--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -48,16 +48,18 @@ try {
             break;
         }
     }
-
-    // Get latest security alerts
-    $security_alerts = $api->request('/security/alerts?limit=3');
-    
 } catch (Exception $e) {
     $_SESSION['flash_message'] = "Erreur lors du chargement des données: " . $e->getMessage();
     $_SESSION['flash_type'] = "error";
-    
+
     $security_articles = [];
     $security_threads = [];
+}
+
+// Load security alerts separately to avoid wiping article data if unavailable
+try {
+    $security_alerts = $api->request('/security/alerts?limit=3');
+} catch (Exception $e) {
     $security_alerts = [];
 }
 ?>

--- a/dev.php
+++ b/dev.php
@@ -48,16 +48,18 @@ try {
             break;
         }
     }
-
-    // Get trending technologies
-    $trending_techs = $api->request('/technologies/trending?limit=5');
-    
 } catch (Exception $e) {
     $_SESSION['flash_message'] = "Erreur lors du chargement des données: " . $e->getMessage();
     $_SESSION['flash_type'] = "error";
-    
+
     $dev_articles = [];
     $dev_threads = [];
+}
+
+// Try to load trending technologies separately so a 404 doesn't clear articles
+try {
+    $trending_techs = $api->request('/technologies/trending?limit=5');
+} catch (Exception $e) {
     $trending_techs = [];
 }
 ?>


### PR DESCRIPTION
## Summary
- avoid clearing dev data when trending tech endpoint fails
- avoid clearing security data when security alerts endpoint fails

## Testing
- `php -l dev.php` *(fails: `php` not installed)*
- `./vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870362746148332ab782948058310f7