### PR TITLE
Fix reply submission

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -316,6 +316,12 @@ curl -H "Authorization: Bearer <TOKEN>" -X DELETE http://localhost:8000/forum/th
 ### POST /forum/threads/{thread_id}/replies
 Répondre à un fil *(token requis)*.
 
+Corps JSON :
+- `thread_id`
+- `content`
+- `user_id` *(optionnel)*
+- `parent_id` *(optionnel)*
+
 ```bash
 curl -H "Authorization: Bearer <TOKEN>" \
      -X POST -H "Content-Type: application/json" \

--- a/thread.php
+++ b/thread.php
@@ -131,9 +131,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $api->isLoggedIn() && verify_csrf_t
         $reply_error = "Le contenu de la réponse ne peut pas être vide.";
     } else {
         try {
+            $user = $api->getCurrentUser();
             $data = [
                 'thread_id' => $thread_id,
-                'content' => $content
+                'content' => $content,
+                'user_id' => $user['id'] ?? null
             ];
             if ($parent_id) {
                 $data['parent_id'] = $parent_id;


### PR DESCRIPTION
## Summary
- include the current user id when posting a reply
- document required fields for posting replies

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687036926fd48332a07fad1fa4133a42