### PR TITLE
Improve topic tag detection

### DIFF
--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -4,18 +4,22 @@ $page_description = "Information et discussions sur la cybersécurité, les vuln
 require_once 'functions.php';
 require_once 'header.php';
 
-// Retrieve tag id for "cybersécurité"
+// Retrieve tag id for security and map tag ids to names
 $security_tag_id = null;
+$tag_map = [];
 try {
     $tags_list = $api->request('/tags');
     foreach ($tags_list as $t) {
-        if (strtolower($t['name']) === 'cybersécurité' || strtolower($t['name']) === 'cybersecurite') {
-            $security_tag_id = $t['id'];
-            break;
+        if (isset($t['id'])) {
+            $tag_map[$t['id']] = $t['name'] ?? '';
+            if ($security_tag_id === null && detect_topic([$t['name']], $t['name']) === 'security') {
+                $security_tag_id = $t['id'];
+            }
         }
     }
 } catch (Exception $e) {
     $security_tag_id = null;
+    $tag_map = [];
 }
 
 try {
@@ -27,8 +31,17 @@ try {
         $all_articles = $api->request('/articles?limit=20');
         $security_articles = [];
         foreach ($all_articles as $article) {
-            $tags = array_column($article['tags'] ?? [], 'name');
-            if (detect_topic($tags, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'security') {
+            $tag_names = [];
+            if (isset($article['tags']) && is_array($article['tags'])) {
+                foreach ($article['tags'] as $t) {
+                    if (is_array($t) && isset($t['name'])) {
+                        $tag_names[] = $t['name'];
+                    } elseif (isset($tag_map[$t])) {
+                        $tag_names[] = $tag_map[$t];
+                    }
+                }
+            }
+            if (detect_topic($tag_names, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'security') {
                 $security_articles[] = $article;
             }
             if (count($security_articles) >= 6) {
@@ -48,16 +61,18 @@ try {
             break;
         }
     }
-
-    // Get latest security alerts
-    $security_alerts = $api->request('/security/alerts?limit=3');
-    
 } catch (Exception $e) {
     $_SESSION['flash_message'] = "Erreur lors du chargement des données: " . $e->getMessage();
     $_SESSION['flash_type'] = "error";
-    
+
     $security_articles = [];
     $security_threads = [];
+}
+
+// Load security alerts separately to avoid wiping article data if unavailable
+try {
+    $security_alerts = $api->request('/security/alerts?limit=3');
+} catch (Exception $e) {
     $security_alerts = [];
 }
 ?>

--- a/dev.php
+++ b/dev.php
@@ -4,18 +4,22 @@ $page_description = "Ressources, articles et discussions sur le développement i
 require_once 'functions.php';
 require_once 'header.php';
 
-// Retrieve tag id for "développement"
+// Retrieve tag id for development and map tag ids to names
 $dev_tag_id = null;
+$tag_map = [];
 try {
     $tags_list = $api->request('/tags');
     foreach ($tags_list as $t) {
-        if (strtolower($t['name']) === 'développement') {
-            $dev_tag_id = $t['id'];
-            break;
+        if (isset($t['id'])) {
+            $tag_map[$t['id']] = $t['name'] ?? '';
+            if ($dev_tag_id === null && detect_topic([$t['name']], $t['name']) === 'dev') {
+                $dev_tag_id = $t['id'];
+            }
         }
     }
 } catch (Exception $e) {
     $dev_tag_id = null;
+    $tag_map = [];
 }
 
 try {
@@ -27,8 +31,17 @@ try {
         $all_articles = $api->request('/articles?limit=20');
         $dev_articles = [];
         foreach ($all_articles as $article) {
-            $tags = array_column($article['tags'] ?? [], 'name');
-            if (detect_topic($tags, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'dev') {
+            $tag_names = [];
+            if (isset($article['tags']) && is_array($article['tags'])) {
+                foreach ($article['tags'] as $t) {
+                    if (is_array($t) && isset($t['name'])) {
+                        $tag_names[] = $t['name'];
+                    } elseif (isset($tag_map[$t])) {
+                        $tag_names[] = $tag_map[$t];
+                    }
+                }
+            }
+            if (detect_topic($tag_names, ($article['title'] ?? '') . ' ' . ($article['content'] ?? '')) === 'dev') {
                 $dev_articles[] = $article;
             }
             if (count($dev_articles) >= 6) {
@@ -48,16 +61,18 @@ try {
             break;
         }
     }
-
-    // Get trending technologies
-    $trending_techs = $api->request('/technologies/trending?limit=5');
-    
 } catch (Exception $e) {
     $_SESSION['flash_message'] = "Erreur lors du chargement des données: " . $e->getMessage();
     $_SESSION['flash_type'] = "error";
-    
+
     $dev_articles = [];
     $dev_threads = [];
+}
+
+// Try to load trending technologies separately so a 404 doesn't clear articles
+try {
+    $trending_techs = $api->request('/technologies/trending?limit=5');
+} catch (Exception $e) {
     $trending_techs = [];
 }
 ?>


### PR DESCRIPTION
## Summary
- better match dev/cyber tags by checking keywords
- map tag IDs to names when filtering articles

## Testing
- `php -l dev.php`
- `php -l cyber-securite.php`
- `phpunit tests/ArticleControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6870362746148332ab782948058310f7