### PR TITLE
Add CERT-FR security alerts

### DIFF
--- a/controllers/HomeController.php
+++ b/controllers/HomeController.php
@@ -16,6 +16,9 @@ class HomeController {
             $categories = $this->api->request('/forum/categories');
             // Get popular threads
             $popular_threads = $this->api->request('/forum/threads?skip=0&limit=5');
+            // Fetch latest CERT-FR security alert
+            $cert_alerts = fetch_cert_alerts(1);
+            $latest_cert_alert = $cert_alerts[0] ?? null;
         } catch (Exception $e) {
             $_SESSION['flash_message'] = "Erreur lors du chargement des données: " . $e->getMessage();
             $_SESSION['flash_type'] = "error";

--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -69,9 +69,9 @@ try {
     $security_threads = [];
 }
 
-// Load security alerts separately to avoid wiping article data if unavailable
+// Load security alerts from CERT-FR RSS feed
 try {
-    $security_alerts = $api->request('/security/alerts?limit=3');
+    $security_alerts = fetch_cert_alerts(3);
 } catch (Exception $e) {
     $security_alerts = [];
 }
@@ -101,27 +101,23 @@ try {
         <section class="security-alerts-section" style="margin-bottom: 3rem;">
             <div class="section-header" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
                 <h2 style="display: flex; align-items: center; gap: 0.75rem;"><i class="fas fa-shield-alt" style="color: var(--accent-red);"></i> Alertes de Sécurité</h2>
-                <a href="#" class="view-all">Toutes les alertes <i class="fas fa-arrow-right"></i></a>
+                <a href="https://www.cert.ssi.gouv.fr/alerte/" target="_blank" rel="noopener" class="view-all">Toutes les alertes <i class="fas fa-arrow-right"></i></a>
             </div>
             
             <?php if (!empty($security_alerts)): ?>
                 <div class="alerts-container">
                     <?php foreach ($security_alerts as $alert): ?>
-                        <div class="security-alert" style="border-left-color: <?php echo $alert['severity'] === 'high' ? 'var(--accent-red)' : ($alert['severity'] === 'medium' ? 'var(--bright-blue)' : 'var(--purple)'); ?>;">
+                        <div class="security-alert" style="border-left-color: var(--accent-red);">
                             <h4>
-                                <i class="fas fa-exclamation-triangle" style="color: <?php echo $alert['severity'] === 'high' ? 'var(--accent-red)' : ($alert['severity'] === 'medium' ? 'var(--bright-blue)' : 'var(--purple)'); ?>;"></i>
+                                <i class="fas fa-exclamation-triangle" style="color: var(--accent-red);"></i>
                                 <?php echo htmlspecialchars($alert['title']); ?>
-                                
-                                <span class="badge" style="font-size: 0.7rem; background-color: <?php echo $alert['severity'] === 'high' ? 'var(--accent-red)' : ($alert['severity'] === 'medium' ? 'var(--bright-blue)' : 'var(--purple)'); ?>; float: right;">
-                                    <?php echo $alert['severity'] === 'high' ? 'CRITIQUE' : ($alert['severity'] === 'medium' ? 'MODÉRÉ' : 'FAIBLE'); ?>
-                                </span>
                             </h4>
-                            
-                            <p><?php echo htmlspecialchars($alert['description']); ?></p>
-                            
+
+                            <p><?php echo htmlspecialchars(mb_strimwidth($alert['description'], 0, 200, '...')); ?></p>
+
                             <div style="margin-top: 1rem; display: flex; justify-content: space-between; align-items: center; font-size: 0.875rem;">
-                                <span>Publié le <?php echo date('d/m/Y', strtotime($alert['created_at'])); ?></span>
-                                <a href="#" class="btn btn-sm btn-outline">
+                                <span>Publié le <?php echo date('d/m/Y', strtotime($alert['pubDate'])); ?></span>
+                                <a href="<?php echo htmlspecialchars($alert['link']); ?>" class="btn btn-sm btn-outline" target="_blank" rel="noopener">
                                     Plus de détails
                                 </a>
                             </div>

--- a/functions.php
+++ b/functions.php
@@ -143,4 +143,46 @@ function get_username(array $data) {
     }
     return null;
 }
+
+/**
+ * Fetch latest security alerts from CERT-FR RSS feed.
+ *
+ * @param int $limit Number of alerts to retrieve
+ * @return array[] List of alerts with title, link, description and pubDate
+ */
+function fetch_cert_alerts($limit = 1) {
+    $feed_url = 'https://www.cert.ssi.gouv.fr/alerte/feed/';
+    $alerts = [];
+
+    $context = stream_context_create([
+        'http' => [
+            'user_agent' => 'KopoForumBot/1.0',
+            'timeout' => 5
+        ]
+    ]);
+
+    $feed = @file_get_contents($feed_url, false, $context);
+    if ($feed === false) {
+        return $alerts;
+    }
+
+    $xml = @simplexml_load_string($feed);
+    if ($xml === false || empty($xml->channel->item)) {
+        return $alerts;
+    }
+
+    foreach ($xml->channel->item as $item) {
+        $alerts[] = [
+            'title' => (string)$item->title,
+            'link' => (string)$item->link,
+            'description' => strip_tags((string)$item->description),
+            'pubDate' => (string)$item->pubDate
+        ];
+        if (count($alerts) >= $limit) {
+            break;
+        }
+    }
+
+    return $alerts;
+}
 ?>

--- a/views/home.php
+++ b/views/home.php
@@ -166,11 +166,13 @@
                     </div>
                 </section>
                 <!-- Cybersecurity Alert -->
+                <?php if (isset($latest_cert_alert)): ?>
                 <section class="security-alert" style="margin-top: 3rem;">
-                    <h4><i class="fas fa-shield-alt"></i> Alerte de sécurité</h4>
-                    <p>Mise à jour importante concernant la vulnérabilité critique Log4Shell (CVE-2021-44228). Assurez-vous que vos systèmes sont protégés contre cette faille.</p>
-                    <p><a href="article.php?id=cybersecurity-alert" class="btn btn-accent" style="margin-top: 0.5rem;">En savoir plus</a></p>
+                    <h4><i class="fas fa-shield-alt"></i> <?php echo htmlspecialchars($latest_cert_alert['title']); ?></h4>
+                    <p><?php echo htmlspecialchars(mb_strimwidth($latest_cert_alert['description'], 0, 200, '...')); ?></p>
+                    <p><a href="<?php echo htmlspecialchars($latest_cert_alert['link']); ?>" class="btn btn-accent" style="margin-top: 0.5rem;" target="_blank" rel="noopener">En savoir plus</a></p>
                 </section>
+                <?php endif; ?>
                 <!-- CTA Section -->
                 <section class="cta-section" style="margin: 3rem 0; padding: 3rem; background-color: var(--dark-blue); color: var(--white); border-radius: var(--border-radius); text-align: center;">
                     <h2 style="color: var(--white); font-size: 2rem; margin-bottom: 1.5rem;">Rejoignez la conversation</h2>


### PR DESCRIPTION
## Summary
- fetch CERT-FR RSS alerts via new `fetch_cert_alerts` helper
- show latest alert on homepage
- list recent CERT-FR alerts on Cyber Sécurité page

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_687042ae73348332a7a7f72d9a9dbbee