### PR TITLE
Add CERT-FR RSS security alerts

### DIFF
--- a/controllers/HomeController.php
+++ b/controllers/HomeController.php
@@ -16,9 +16,13 @@ class HomeController {
             $categories = $this->api->request('/forum/categories');
             // Get popular threads
             $popular_threads = $this->api->request('/forum/threads?skip=0&limit=5');
+            // Load latest CERT-FR alert
+            $alerts = fetch_cert_alerts(1);
+            $latest_security_alert = $alerts[0] ?? null;
         } catch (Exception $e) {
             $_SESSION['flash_message'] = "Erreur lors du chargement des données: " . $e->getMessage();
             $_SESSION['flash_type'] = "error";
+            $latest_security_alert = null;
         }
 
         require __DIR__ . '/../views/templates/header.php';

--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -69,9 +69,9 @@ try {
     $security_threads = [];
 }
 
-// Load security alerts separately to avoid wiping article data if unavailable
+// Load security alerts from CERT-FR RSS feed
 try {
-    $security_alerts = $api->request('/security/alerts?limit=3');
+    $security_alerts = fetch_cert_alerts(3);
 } catch (Exception $e) {
     $security_alerts = [];
 }
@@ -101,27 +101,23 @@ try {
         <section class="security-alerts-section" style="margin-bottom: 3rem;">
             <div class="section-header" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
                 <h2 style="display: flex; align-items: center; gap: 0.75rem;"><i class="fas fa-shield-alt" style="color: var(--accent-red);"></i> Alertes de Sécurité</h2>
-                <a href="#" class="view-all">Toutes les alertes <i class="fas fa-arrow-right"></i></a>
+                <a href="https://www.cert.ssi.gouv.fr/alerte/" target="_blank" rel="noopener noreferrer" class="view-all">Toutes les alertes <i class="fas fa-arrow-right"></i></a>
             </div>
             
             <?php if (!empty($security_alerts)): ?>
                 <div class="alerts-container">
                     <?php foreach ($security_alerts as $alert): ?>
-                        <div class="security-alert" style="border-left-color: <?php echo $alert['severity'] === 'high' ? 'var(--accent-red)' : ($alert['severity'] === 'medium' ? 'var(--bright-blue)' : 'var(--purple)'); ?>;">
+                        <div class="security-alert" style="border-left-color: var(--accent-red);">
                             <h4>
-                                <i class="fas fa-exclamation-triangle" style="color: <?php echo $alert['severity'] === 'high' ? 'var(--accent-red)' : ($alert['severity'] === 'medium' ? 'var(--bright-blue)' : 'var(--purple)'); ?>;"></i>
+                                <i class="fas fa-exclamation-triangle" style="color: var(--accent-red);"></i>
                                 <?php echo htmlspecialchars($alert['title']); ?>
-                                
-                                <span class="badge" style="font-size: 0.7rem; background-color: <?php echo $alert['severity'] === 'high' ? 'var(--accent-red)' : ($alert['severity'] === 'medium' ? 'var(--bright-blue)' : 'var(--purple)'); ?>; float: right;">
-                                    <?php echo $alert['severity'] === 'high' ? 'CRITIQUE' : ($alert['severity'] === 'medium' ? 'MODÉRÉ' : 'FAIBLE'); ?>
-                                </span>
                             </h4>
-                            
-                            <p><?php echo htmlspecialchars($alert['description']); ?></p>
-                            
+
+                            <p><?php echo htmlspecialchars(strip_tags($alert['description'])); ?></p>
+
                             <div style="margin-top: 1rem; display: flex; justify-content: space-between; align-items: center; font-size: 0.875rem;">
-                                <span>Publié le <?php echo date('d/m/Y', strtotime($alert['created_at'])); ?></span>
-                                <a href="#" class="btn btn-sm btn-outline">
+                                <span>Publié le <?php echo date('d/m/Y', strtotime($alert['pubDate'])); ?></span>
+                                <a href="<?php echo htmlspecialchars($alert['link']); ?>" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline">
                                     Plus de détails
                                 </a>
                             </div>

--- a/functions.php
+++ b/functions.php
@@ -143,4 +143,41 @@ function get_username(array $data) {
     }
     return null;
 }
+
+/**
+ * Retrieve security alerts from CERT-FR RSS feed.
+ *
+ * @param int $limit Number of alerts to return
+ * @return array[] List of alerts with title, link, description and pubDate
+ */
+function fetch_cert_alerts(int $limit = 5) {
+    $url = 'https://www.cert.ssi.gouv.fr/feed/';
+    $context = stream_context_create([
+        'http' => ['timeout' => 5]
+    ]);
+    $rss = @file_get_contents($url, false, $context);
+    if ($rss === false) {
+        return [];
+    }
+
+    libxml_use_internal_errors(true);
+    $xml = simplexml_load_string($rss);
+    if ($xml === false || empty($xml->channel->item)) {
+        return [];
+    }
+
+    $alerts = [];
+    foreach ($xml->channel->item as $item) {
+        $alerts[] = [
+            'title' => (string) $item->title,
+            'link' => (string) $item->link,
+            'description' => (string) $item->description,
+            'pubDate' => (string) $item->pubDate
+        ];
+        if (count($alerts) >= $limit) {
+            break;
+        }
+    }
+    return $alerts;
+}
 ?>

--- a/views/home.php
+++ b/views/home.php
@@ -168,8 +168,12 @@
                 <!-- Cybersecurity Alert -->
                 <section class="security-alert" style="margin-top: 3rem;">
                     <h4><i class="fas fa-shield-alt"></i> Alerte de sécurité</h4>
-                    <p>Mise à jour importante concernant la vulnérabilité critique Log4Shell (CVE-2021-44228). Assurez-vous que vos systèmes sont protégés contre cette faille.</p>
-                    <p><a href="article.php?id=cybersecurity-alert" class="btn btn-accent" style="margin-top: 0.5rem;">En savoir plus</a></p>
+                    <?php if (!empty($latest_security_alert)): ?>
+                        <p><?php echo htmlspecialchars($latest_security_alert['title']); ?></p>
+                        <p><a href="<?php echo htmlspecialchars($latest_security_alert['link']); ?>" target="_blank" rel="noopener noreferrer" class="btn btn-accent" style="margin-top: 0.5rem;">En savoir plus</a></p>
+                    <?php else: ?>
+                        <p>Aucune alerte de sécurité disponible actuellement.</p>
+                    <?php endif; ?>
                 </section>
                 <!-- CTA Section -->
                 <section class="cta-section" style="margin: 3rem 0; padding: 3rem; background-color: var(--dark-blue); color: var(--white); border-radius: var(--border-radius); text-align: center;">


### PR DESCRIPTION
## Summary
- fetch security alerts from CERT-FR RSS feed
- show the latest alert on the home page
- list recent CERT alerts in the cybersecurity page

## Testing
- `phpunit tests/ArticleControllerTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704c43762c833286060397734404cc