### PR TITLE
Add security alert feed endpoints

### DIFF
--- a/API_DEV_GUIDE.md
+++ b/API_DEV_GUIDE.md
@@ -347,6 +347,20 @@ Supprimer une réponse *(token requis)*.
 curl -H "Authorization: Bearer <TOKEN>" -X DELETE http://localhost:8000/forum/replies/3
 ```
 
+### GET /security/alerts
+Lister les dernières alertes de sécurité publiées par CERT-FR.
+
+```bash
+curl http://localhost:8000/security/alerts
+```
+
+### GET /security/alerts/latest
+Obtenir la toute dernière alerte de sécurité CERT-FR.
+
+```bash
+curl http://localhost:8000/security/alerts/latest
+```
+
 ### GET /reporting/config
 Récupérer la configuration des signalements.
 

--- a/README.md
+++ b/README.md
@@ -71,4 +71,7 @@ The API will be available on port **8000** of the container. Replace
 - `PUT/PATCH /forum/replies/{id}` – edit a reply *(requires token)*
 - `DELETE /forum/replies/{id}` – delete a reply *(requires token)*
 
+- `GET /security/alerts` – list recent CERT-FR security alerts
+- `GET /security/alerts/latest` – fetch the latest CERT-FR alert
+
 This is only a starting point. More models and endpoints can be added following the same pattern.

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,8 @@ import os
 import uuid
 import shutil
 import html
+import requests
+import feedparser
 
 from . import models, schemas
 from .database import Base, engine, get_db
@@ -607,3 +609,42 @@ def get_reporting_config(db: Session = Depends(get_db)):
     if not config:
         raise HTTPException(status_code=404, detail="Config not found")
     return config
+
+
+CERTFR_FEED_URL = "https://www.cert.ssi.gouv.fr/feed/"
+
+
+def _fetch_certfr_feed(limit: int = 10):
+    """Retrieve and parse the CERT-FR RSS feed."""
+    try:
+        resp = requests.get(CERTFR_FEED_URL, timeout=10)
+        resp.raise_for_status()
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to fetch RSS feed: {exc}") from exc
+    feed = feedparser.parse(resp.text)
+    alerts = []
+    for entry in feed.entries[:limit]:
+        alerts.append(
+            schemas.SecurityAlertOut(
+                title=entry.get("title", ""),
+                link=entry.get("link", ""),
+                summary=entry.get("summary"),
+                published=entry.get("published"),
+            )
+        )
+    return alerts
+
+
+@app.get("/security/alerts", response_model=list[schemas.SecurityAlertOut])
+def list_security_alerts(limit: int = 5):
+    """Return the most recent security alerts from CERT-FR."""
+    return _fetch_certfr_feed(limit)
+
+
+@app.get("/security/alerts/latest", response_model=schemas.SecurityAlertOut)
+def latest_security_alert():
+    """Return the latest security alert from CERT-FR."""
+    alerts = _fetch_certfr_feed(limit=1)
+    if not alerts:
+        raise HTTPException(status_code=404, detail="No alerts found")
+    return alerts[0]

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -388,3 +388,11 @@ class ReportingConfigOut(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class SecurityAlertOut(BaseModel):
+    """Schema for items parsed from the CERT-FR RSS feed."""
+    title: str
+    link: str
+    summary: Optional[str] = None
+    published: Optional[str] = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests
 passlib[bcrypt]
 bcrypt<4
 python-jose
+feedparser


### PR DESCRIPTION
## Summary
- fetch security alerts from CERT-FR RSS feed
- expose `/security/alerts` and `/security/alerts/latest`
- document new endpoints in README and API_DEV_GUIDE
- add feedparser dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68704f726e6483329cf7c5ad4d3abcc4