### PR TITLE
Improve security alert UI

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1033,6 +1033,8 @@ textarea.form-control {
   margin-bottom: 1.5rem;
   border-left: 4px solid var(--accent-red);
   background-color: #fff7f8;
+  border-radius: var(--border-radius);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 .security-alert h4 {

--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -120,7 +120,7 @@ try {
                             <p><?php echo htmlspecialchars($alert['description']); ?></p>
                             
                             <div style="margin-top: 1rem; display: flex; justify-content: space-between; align-items: center; font-size: 0.875rem;">
-                                <span>Publié le <?php echo date('d/m/Y', strtotime($alert['created_at'])); ?></span>
+                                <span>Publié le <?php echo date('d/m/Y', strtotime($alert['published'] ?? $alert['created_at'])); ?></span>
                                 <a href="<?php echo htmlspecialchars($alert['link']); ?>" target="_blank" rel="noopener" class="btn btn-sm btn-outline">
                                     Voir sur CERT-FR
                                 </a>


### PR DESCRIPTION
## Summary
- refine security alert styles with rounded corners and subtle shadow
- show published date on the cyber security page if available

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870574b77e083329cff6a5e870dd6bb