### PR TITLE
Adjust security alert layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1029,8 +1029,8 @@ textarea.form-control {
 }
 
 .security-alert {
-  padding: 1.25rem;
-  margin-bottom: 1.5rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
   border-left: 4px solid var(--accent-red);
   background-color: #fff7f8;
   border-radius: var(--border-radius);
@@ -1042,6 +1042,10 @@ textarea.form-control {
   align-items: center;
   gap: 0.5rem;
   color: var(--accent-red);
+  margin-bottom: 0.5rem;
+}
+
+.security-alert p {
   margin-bottom: 0.75rem;
 }
 

--- a/cyber-securite.php
+++ b/cyber-securite.php
@@ -119,7 +119,7 @@ try {
                             
                             <p><?php echo htmlspecialchars($alert['description']); ?></p>
                             
-                            <div style="margin-top: 1rem; display: flex; justify-content: space-between; align-items: center; font-size: 0.875rem;">
+                            <div style="margin-top: 0.75rem; display: flex; justify-content: space-between; align-items: center; font-size: 0.875rem;">
                                 <span>Publié le <?php echo date('d/m/Y', strtotime($alert['published'] ?? $alert['created_at'])); ?></span>
                                 <a href="<?php echo htmlspecialchars($alert['link']); ?>" target="_blank" rel="noopener" class="btn btn-sm btn-outline">
                                     Voir sur CERT-FR


### PR DESCRIPTION
## Summary
- shorten padding and margins for security alerts
- reduce spacing in cybersecurity page alerts section

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687059c4ec448332b5d8f492fc8a4c43