### PR TITLE
Fix forum statistics counters

### DIFF
--- a/category.php
+++ b/category.php
@@ -27,7 +27,17 @@ try {
     }
 
     $threads = $api->request('/forum/threads?category_id=' . $category_id . '&skip=' . $skip . '&limit=' . $limit);
-    $total_pages = isset($category['thread_count']) ? max(1, ceil($category['thread_count'] / $limit)) : 1;
+
+    $total_threads = $category['thread_count'] ?? null;
+    if ($total_threads === null) {
+        try {
+            $all_threads = $api->request('/forum/threads?category_id=' . $category_id);
+            $total_threads = is_array($all_threads) ? count($all_threads) : count($threads);
+        } catch (Exception $e) {
+            $total_threads = count($threads);
+        }
+    }
+    $total_pages = max(1, ceil($total_threads / $limit));
 
     $page_title = $category['name'];
     $page_description = isset($category['description']) ? $category['description'] : 'Discussions dans la catégorie ' . $category['name'];

--- a/functions.php
+++ b/functions.php
@@ -82,7 +82,8 @@ function calculate_forum_stats($api) {
     ];
 
     try {
-        $stats['user_count'] = (int)$api->request('/users/count');
+        $count_res = $api->request('/users/count');
+        $stats['user_count'] = $count_res['count'] ?? 0;
     } catch (Exception $e) {
         // ignore errors
     }
@@ -90,8 +91,18 @@ function calculate_forum_stats($api) {
     try {
         $categories = $api->request('/forum/categories');
         foreach ($categories as $cat) {
-            $stats['thread_count'] += $cat['thread_count'] ?? 0;
-            $stats['reply_count'] += $cat['reply_count'] ?? 0;
+            if (isset($cat['thread_count']) && isset($cat['reply_count'])) {
+                $stats['thread_count'] += $cat['thread_count'];
+                $stats['reply_count'] += $cat['reply_count'];
+            } else {
+                $threads = $api->request('/forum/threads?category_id=' . $cat['id']);
+                $stats['thread_count'] += is_array($threads) ? count($threads) : 0;
+                if (is_array($threads)) {
+                    foreach ($threads as $t) {
+                        $stats['reply_count'] += $t['reply_count'] ?? 0;
+                    }
+                }
+            }
         }
     } catch (Exception $e) {
         // ignore errors
@@ -101,14 +112,21 @@ function calculate_forum_stats($api) {
         try {
             $users = $api->request('/users?skip=0&limit=' . $stats['user_count']);
             $bestUser = null;
-            $bestScore = -1;
+            $maxArticles = -1;
             foreach ($users as $user) {
-                $score = ($user['thread_count'] ?? 0)
-                       + ($user['reply_count'] ?? 0)
-                       + ($user['article_count'] ?? 0);
-                if ($score > $bestScore) {
-                    $bestScore = $score;
+                $articleCount = $user['article_count'] ?? null;
+                if ($articleCount === null) {
+                    try {
+                        $arts = $api->request('/users/' . $user['id'] . '/articles');
+                        $articleCount = is_array($arts) ? count($arts) : 0;
+                    } catch (Exception $e) {
+                        $articleCount = 0;
+                    }
+                }
+                if ($articleCount > $maxArticles) {
+                    $maxArticles = $articleCount;
                     $bestUser = $user;
+                    $bestUser['article_count'] = $articleCount;
                 }
             }
             if ($bestUser) {

--- a/views/forums.php
+++ b/views/forums.php
@@ -22,8 +22,22 @@
                         $thread_count = 0;
                         $reply_count = 0;
                         foreach ($categories as $cat) {
-                            $thread_count += $cat['thread_count'] ?? 0;
-                            $reply_count += $cat['reply_count'] ?? 0;
+                            if (isset($cat['thread_count']) && isset($cat['reply_count'])) {
+                                $thread_count += $cat['thread_count'];
+                                $reply_count += $cat['reply_count'];
+                            } else {
+                                try {
+                                    $threads = $api->request('/forum/threads?category_id=' . $cat['id']);
+                                    $thread_count += is_array($threads) ? count($threads) : 0;
+                                    if (is_array($threads)) {
+                                        foreach ($threads as $t) {
+                                            $reply_count += $t['reply_count'] ?? 0;
+                                        }
+                                    }
+                                } catch (Exception $e) {
+                                    // ignore
+                                }
+                            }
                         }
                         ?>
                         &bull; <span><?php echo $thread_count; ?> Discussions</span> 
@@ -50,9 +64,28 @@
                                 <div class="forum-category">
                                     <div class="category-header">
                                         <h3 class="category-title"><?php echo htmlspecialchars($category['name']); ?></h3>
+                                        <?php
+                                            $catThread = $category['thread_count'] ?? null;
+                                            $catReply = $category['reply_count'] ?? null;
+                                            if ($catThread === null || $catReply === null) {
+                                                try {
+                                                    $allThreads = $api->request('/forum/threads?category_id=' . $category['id']);
+                                                    $catThread = is_array($allThreads) ? count($allThreads) : 0;
+                                                    $catReply = 0;
+                                                    if (is_array($allThreads)) {
+                                                        foreach ($allThreads as $th) {
+                                                            $catReply += $th['reply_count'] ?? 0;
+                                                        }
+                                                    }
+                                                } catch (Exception $e) {
+                                                    $catThread = 0;
+                                                    $catReply = 0;
+                                                }
+                                            }
+                                        ?>
                                         <span class="category-stats">
-                                            <?php echo $category['thread_count'] ?? 0; ?> discussions &bull; 
-                                            <?php echo $category['reply_count'] ?? 0; ?> messages
+                                            <?php echo $catThread; ?> discussions &bull;
+                                            <?php echo $catReply; ?> messages
                                         </span>
                                     </div>
                                     

--- a/views/home.php
+++ b/views/home.php
@@ -30,12 +30,27 @@
                                 <div class="forum-category">
                                     <div class="category-header">
                                         <h3 class="category-title"><?php echo htmlspecialchars($category['name']); ?></h3>
+                                        <?php
+                                            $catThread = $category['thread_count'] ?? null;
+                                            $catReply = $category['reply_count'] ?? null;
+                                            if ($catThread === null || $catReply === null) {
+                                                try {
+                                                    $allThreads = $this->api->request('/forum/threads?category_id=' . $category['id']);
+                                                    $catThread = is_array($allThreads) ? count($allThreads) : 0;
+                                                    $catReply = 0;
+                                                    if (is_array($allThreads)) {
+                                                        foreach ($allThreads as $th) {
+                                                            $catReply += $th['reply_count'] ?? 0;
+                                                        }
+                                                    }
+                                                } catch (Exception $e) {
+                                                    $catThread = 0;
+                                                    $catReply = 0;
+                                                }
+                                            }
+                                        ?>
                                         <span class="category-stats">
-                                            <?php
-                                            echo isset($category['thread_count']) ? $category['thread_count'] . ' discussions' : '0 discussions';
-                                            echo ' · ';
-                                            echo isset($category['reply_count']) ? $category['reply_count'] . ' messages' : '0 messages';
-                                            ?>
+                                            <?php echo $catThread . ' discussions · ' . $catReply . ' messages'; ?>
                                         </span>
                                     </div>
                                     <?php if (isset($category['description'])): ?>


### PR DESCRIPTION
## Summary
- compute `user_count` from API response
- calculate thread and reply counts in PHP if missing from the API
- determine most active user by article count
- fix category page pagination when counts missing
- update forum and home views to show accurate counts

## Testing
- `php -v` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68705b3dd5948332a2193e761a1611c9