### PR TITLE
Sort featured articles by date

### DIFF
--- a/controllers/HomeController.php
+++ b/controllers/HomeController.php
@@ -10,8 +10,15 @@ class HomeController {
         $page_title = 'Accueil';
         $page_description = "Forum de discussion et actualités sur l'informatique, la cybersécurité et les technologies";
         try {
-            // Get latest articles
+            // Get latest articles and ensure newest first
             $latest_articles = $this->api->request('/articles?skip=0&limit=3');
+            if (is_array($latest_articles)) {
+                usort($latest_articles, function ($a, $b) {
+                    $dateA = isset($a['created_at']) ? strtotime($a['created_at']) : 0;
+                    $dateB = isset($b['created_at']) ? strtotime($b['created_at']) : 0;
+                    return $dateB <=> $dateA; // newest first
+                });
+            }
             // Get forum categories
             $categories = $this->api->request('/forum/categories');
             // Get popular threads


### PR DESCRIPTION
## Summary
- ensure featured articles on the home page are ordered from newest to oldest

## Testing
- `phpunit tests/ArticleControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68706856ebe0833280444527579cdb07