### PR TITLE
Remove reputation and fix member post count

### DIFF
--- a/controllers/MembersController.php
+++ b/controllers/MembersController.php
@@ -19,9 +19,6 @@ class MembersController {
             case 'activity':
                 $sort_param = '&sort=activity';
                 break;
-            case 'reputation':
-                $sort_param = '&sort=reputation';
-                break;
             case 'a-z':
                 $sort_param = '&sort=username';
                 break;
@@ -51,6 +48,26 @@ class MembersController {
             $_SESSION['flash_type'] = "error";
             $members_data = [];
         }
+
+        // Ensure post_count equals total threads + articles for each member
+        foreach ($members_data as &$member) {
+            $threads = [];
+            $articles = [];
+            try {
+                $threads = $this->api->request('/users/' . $member['id'] . '/threads');
+            } catch (Exception $e) {
+                $threads = [];
+            }
+            try {
+                $articles = $this->api->request('/users/' . $member['id'] . '/articles');
+            } catch (Exception $e) {
+                $articles = [];
+            }
+            $thread_count = is_array($threads) ? count($threads) : 0;
+            $article_count = is_array($articles) ? count($articles) : 0;
+            $member['post_count'] = $thread_count + $article_count;
+        }
+        unset($member);
 
         try {
             if (!empty($search)) {

--- a/views/members.php
+++ b/views/members.php
@@ -28,7 +28,6 @@
                 <div class="btn-group" style="display: inline-flex;">
                     <a href="?sort=newest<?php echo !empty($search) ? '&search=' . urlencode($search) : ''; ?>" class="btn btn-sm <?php echo $sort === 'newest' ? 'btn-primary' : 'btn-outline'; ?>">Récent</a>
                     <a href="?sort=activity<?php echo !empty($search) ? '&search=' . urlencode($search) : ''; ?>" class="btn btn-sm <?php echo $sort === 'activity' ? 'btn-primary' : 'btn-outline'; ?>">Activité</a>
-                    <a href="?sort=reputation<?php echo !empty($search) ? '&search=' . urlencode($search) : ''; ?>" class="btn btn-sm <?php echo $sort === 'reputation' ? 'btn-primary' : 'btn-outline'; ?>">Réputation</a>
                     <a href="?sort=a-z<?php echo !empty($search) ? '&search=' . urlencode($search) : ''; ?>" class="btn btn-sm <?php echo $sort === 'a-z' ? 'btn-primary' : 'btn-outline'; ?>">A-Z</a>
                 </div>
             </div>
@@ -76,10 +75,6 @@
                                     <div style="font-size: 0.75rem; color: #666;">Posts</div>
                                 </div>
                                 
-                                <div class="stat-item">
-                                    <div style="font-weight: 600;"><?php echo $member['reputation'] ?? 0; ?></div>
-                                    <div style="font-size: 0.75rem; color: #666;">Réputation</div>
-                                </div>
                                 
                                 <div class="stat-item">
                                     <div style="font-weight: 600;"><?php echo isset($member['created_at']) ? date('m/Y', strtotime($member['created_at'])) : 'N/A'; ?></div>


### PR DESCRIPTION
## Summary
- clean up reputation sorting and displays from member listings
- compute post_count from member articles and threads to ensure accuracy

## Testing
- `phpunit tests/ArticleControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_687067de9e8083329f3fc1200f26beab