### PR TITLE
Fix draft management to use /articles endpoint

### DIFF
--- a/controllers/NewArticleController.php
+++ b/controllers/NewArticleController.php
@@ -53,12 +53,8 @@ class NewArticleController {
                         $data['tag_names'] = [$new_tag];
                     }
 
-                    // If the article should remain unpublished, create a draft
-                    $endpoint = $is_published ? '/articles' : '/drafts';
-                    if (!$is_published) {
-                        $data['type'] = 'article';
-                    }
-                    $result = $this->api->request($endpoint, 'POST', $data, true);
+                    // Always use /articles endpoint. Rely on is_pub flag for drafts
+                    $result = $this->api->request('/articles', 'POST', $data, true);
                     if (isset($result['id'])) {
                         $article_id = $result['id'];
                         if (!empty($image_url)) {

--- a/delete-content.php
+++ b/delete-content.php
@@ -98,7 +98,7 @@ try {
             break;
             
         case 'draft':
-            $result = $api->request('/drafts/' . $content_id, 'DELETE', [], true);
+            $result = $api->request('/articles/' . $content_id, 'DELETE', [], true);
             $_SESSION['flash_message'] = "Le brouillon a été supprimé avec succès.";
             break;
             

--- a/edit-article.php
+++ b/edit-article.php
@@ -47,20 +47,13 @@ try {
     }, $article_tags);
     
 } catch (Exception $e) {
-    try {
-        $article = $api->request('/drafts/' . $article_id, 'GET', [], true);
-        $is_draft = true;
-        // Get available tags
-        $tags = $api->request('/tags');
-        $article_tags = isset($article['tags']) ? $article['tags'] : [];
-        $selected_tag_ids = array_map(function($tag) { return $tag['id']; }, $article_tags);
-    } catch (Exception $e2) {
-        $_SESSION['flash_message'] = "Erreur: " . $e2->getMessage();
-        $_SESSION['flash_type'] = "error";
-        header('Location: my-content.php');
-        exit();
-    }
+    $_SESSION['flash_message'] = "Erreur: " . $e->getMessage();
+    $_SESSION['flash_type'] = "error";
+    header('Location: my-content.php');
+    exit();
 }
+
+$is_draft = !$article['is_pub'];
 
 $error = '';
 $success = false;
@@ -105,7 +98,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_toke
                 $article_data['tag_names'] = [$new_tag];
             }
 
-            $endpoint = $is_draft ? '/drafts/' . $article_id : '/articles/' . $article_id;
+            $endpoint = '/articles/' . $article_id;
             $api->request($endpoint, 'PATCH', $article_data, true);
             
             // Handle image upload if present

--- a/my-content.php
+++ b/my-content.php
@@ -43,10 +43,24 @@ try {
     // Get user's threads
     $my_threads = $api->request('/users/' . $user_id . '/threads', 'GET', [], true);
     
-    // Get user's drafts if on drafts tab
+    // Get user's drafts if on drafts tab by filtering articles and threads
     $my_drafts = [];
     if ($active_tab === 'drafts') {
-        $my_drafts = $api->request('/users/' . $user_id . '/drafts', 'GET', [], true);
+        $my_drafts = [];
+        $user_articles = $api->request('/users/' . $user_id . '/articles', 'GET', [], true);
+        foreach ($user_articles as $a) {
+            if (empty($a['is_pub'])) {
+                $a['type'] = 'article';
+                $my_drafts[] = $a;
+            }
+        }
+        $user_threads = $api->request('/users/' . $user_id . '/threads', 'GET', [], true);
+        foreach ($user_threads as $t) {
+            if (empty($t['is_pub'])) {
+                $t['type'] = 'thread';
+                $my_drafts[] = $t;
+            }
+        }
     }
 } catch (Exception $e) {
     $_SESSION['flash_message'] = "Erreur lors du chargement de vos publications: " . $e->getMessage();


### PR DESCRIPTION
## Summary
- post new drafts to `/articles` using `is_pub` flag
- drop fallback to `/drafts` when editing articles
- filter drafts locally in `my-content.php`
- delete drafts via `/articles/{id}`

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_687073ad9d688332897eef25152bb704