### PR TITLE
Fix draft privacy

### DIFF
--- a/controllers/ArticleController.php
+++ b/controllers/ArticleController.php
@@ -49,8 +49,25 @@ class ArticleController {
 
         try {
             $article = $this->fetchArticleWithTags($article_id, $this->api->isLoggedIn());
+
+            // If the article is a draft, only the author or an admin may view it
+            if (isset($article['is_pub']) && !$article['is_pub']) {
+                $authorized = false;
+                if ($this->api->isLoggedIn()) {
+                    $current = $this->api->getCurrentUser();
+                    if (($current['id'] ?? null) === ($article['user_id'] ?? null) || ($current['is_admin'] ?? false)) {
+                        $authorized = true;
+                    }
+                }
+                if (!$authorized) {
+                    http_response_code(404);
+                    require '404.html';
+                    return;
+                }
+            }
+
             $comments = $this->api->request('/articles/' . $article_id . '/comments');
-            $recent_articles = $this->api->request('/articles?skip=0&limit=5');
+            $recent_articles = filter_published($this->api->request('/articles?skip=0&limit=5'));
         } catch (Exception $e) {
             $_SESSION['flash_message'] = "Erreur: " . $e->getMessage();
             $_SESSION['flash_type'] = "error";

--- a/controllers/ArticlesController.php
+++ b/controllers/ArticlesController.php
@@ -15,7 +15,7 @@ class ArticlesController {
             if ($tag_id > 0) {
                 $query .= '&tag=' . $tag_id;
             }
-            $articles_data = $this->api->request($query);
+            $articles_data = filter_published($this->api->request($query));
             $count_query = '/articles/count';
             if ($tag_id > 0) {
                 $count_query .= '?tag=' . $tag_id;
@@ -49,7 +49,7 @@ class ArticlesController {
 
         // Charger quelques articles récents pour la sidebar, ignorer les erreurs
         try {
-            $recent_articles = $this->api->request('/articles?skip=0&limit=5');
+            $recent_articles = filter_published($this->api->request('/articles?skip=0&limit=5'));
         } catch (Exception $e) {
             $recent_articles = [];
         }

--- a/controllers/CybersecuriteController.php
+++ b/controllers/CybersecuriteController.php
@@ -29,10 +29,10 @@ class CybersecuriteController {
         try {
             // Fetch articles using the security tag when available
             if ($security_tag_id !== null) {
-                $security_articles = $this->api->request('/articles?tag=' . $security_tag_id . '&limit=6');
+                $security_articles = filter_published($this->api->request('/articles?tag=' . $security_tag_id . '&limit=6'));
             } else {
                 // Fallback to keyword detection on recent articles
-                $all_articles = $this->api->request('/articles?limit=20');
+                $all_articles = filter_published($this->api->request('/articles?limit=20'));
                 $security_articles = [];
                 foreach ($all_articles as $article) {
                     $tag_names = [];

--- a/controllers/DevController.php
+++ b/controllers/DevController.php
@@ -29,10 +29,10 @@ class DevController {
         try {
             // Fetch articles using the development tag when available
             if ($dev_tag_id !== null) {
-                $dev_articles = $this->api->request('/articles?tag=' . $dev_tag_id . '&limit=6');
+                $dev_articles = filter_published($this->api->request('/articles?tag=' . $dev_tag_id . '&limit=6'));
             } else {
                 // Fallback to keyword detection on recent articles
-                $all_articles = $this->api->request('/articles?limit=20');
+                $all_articles = filter_published($this->api->request('/articles?limit=20'));
                 $dev_articles = [];
                 foreach ($all_articles as $article) {
                     $tag_names = [];

--- a/controllers/HomeController.php
+++ b/controllers/HomeController.php
@@ -11,7 +11,7 @@ class HomeController {
         $page_description = "Forum de discussion et actualités sur l'informatique, la cybersécurité et les technologies";
         try {
             // Get latest articles and ensure newest first
-            $latest_articles = $this->api->request('/articles?skip=0&limit=3');
+            $latest_articles = filter_published($this->api->request('/articles?skip=0&limit=3'));
             if (is_array($latest_articles)) {
                 usort($latest_articles, function ($a, $b) {
                     $dateA = isset($a['created_at']) ? strtotime($a['created_at']) : 0;

--- a/controllers/MembersController.php
+++ b/controllers/MembersController.php
@@ -59,7 +59,7 @@ class MembersController {
                 $threads = [];
             }
             try {
-                $articles = $this->api->request('/users/' . $member['id'] . '/articles');
+                $articles = filter_published($this->api->request('/users/' . $member['id'] . '/articles'));
             } catch (Exception $e) {
                 $articles = [];
             }

--- a/functions.php
+++ b/functions.php
@@ -201,4 +201,18 @@ function get_username(array $data) {
 
     return null;
 }
+
+/**
+ * Filter an array of items to only keep published content when available.
+ *
+ * Items without an `is_pub` flag are left untouched.
+ *
+ * @param array $items List of items returned by the API
+ * @return array Filtered list containing only published items
+ */
+function filter_published(array $items) {
+    return array_values(array_filter($items, function ($it) {
+        return !isset($it['is_pub']) || $it['is_pub'];
+    }));
+}
 ?>

--- a/profile.php
+++ b/profile.php
@@ -26,6 +26,12 @@ try {
     $recent_threads = array_slice($user_threads, 0, 5);
 
     $user_articles = $api->request('/users/' . $user_id . '/articles', 'GET', [], true);
+    $viewer = $api->getCurrentUser();
+    $is_owner = $api->isLoggedIn() && ($viewer['id'] ?? null) === $user_id;
+    $is_admin = $api->isLoggedIn() && ($viewer['is_admin'] ?? false);
+    if (!$is_owner && !$is_admin) {
+        $user_articles = filter_published($user_articles);
+    }
     $article_count = is_array($user_articles) ? count($user_articles) : 0;
     $recent_articles = array_slice($user_articles, 0, 5);
 

--- a/search.php
+++ b/search.php
@@ -35,8 +35,9 @@ if (!empty($q)) {
         $all_results = $api->request($search_query);
 
         if ($search_articles && isset($all_results['articles'])) {
-            $articles = array_slice($all_results['articles'], $skip, $limit);
-            $total_results += count($all_results['articles']);
+            $pub_articles = filter_published($all_results['articles']);
+            $articles = array_slice($pub_articles, $skip, $limit);
+            $total_results += count($pub_articles);
         }
 
         if ($search_threads && isset($all_results['threads'])) {


### PR DESCRIPTION
## Summary
- hide drafts from other users
- restrict article view to the author for unpublished posts
- ensure article lists filter out drafts
- use the new `filter_published` helper for profile and search

## Testing
- `vendor/bin/phpunit tests/ArticleControllerTest.php --display-errors`

------
https://chatgpt.com/codex/tasks/task_e_6870817c16f88332af0338af105ac009