### PR TITLE
Add moderator dashboard

### DIFF
--- a/api.php
+++ b/api.php
@@ -174,6 +174,44 @@ class API {
     public function getCurrentUser() {
         return isset($_SESSION['user']) ? $_SESSION['user'] : null;
     }
+
+    /**
+     * Retrieve roles for a given user via moderator API.
+     *
+     * @param int $user_id
+     * @return array
+     */
+    public function getUserRoles($user_id) {
+        return $this->request('/admin/users/' . $user_id . '/roles', 'GET', [], true);
+    }
+
+    /**
+     * Check if the current user has the moderator role.
+     *
+     * The result is cached in the session to avoid repeated API calls.
+     *
+     * @return bool
+     */
+    public function isModerator() {
+        if (!isset($_SESSION['is_moderator'])) {
+            $_SESSION['is_moderator'] = false;
+            if ($this->isLoggedIn()) {
+                $user = $this->getCurrentUser();
+                try {
+                    $roles = $this->getUserRoles($user['id']);
+                    foreach ($roles as $role) {
+                        if (($role['name'] ?? '') === 'moderator') {
+                            $_SESSION['is_moderator'] = true;
+                            break;
+                        }
+                    }
+                } catch (Exception $e) {
+                    $_SESSION['is_moderator'] = false;
+                }
+            }
+        }
+        return $_SESSION['is_moderator'];
+    }
 }
 
 // Initialize API instance

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1080,6 +1080,27 @@ tr:hover td {
   background-color: #f9f9f9;
 }
 
+/* Simple statistic cards for admin dashboard */
+.stat-card {
+  background-color: var(--white);
+  border-radius: var(--border-radius);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  text-align: center;
+  padding: 1rem;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--dark-blue);
+}
+
+.stat-label {
+  color: #666;
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+}
+
 /* Mobile Navigation */
 .mobile-nav-toggle {
   display: none;

--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -1,0 +1,40 @@
+<?php
+class AdminController {
+    private $api;
+    public function __construct($api) {
+        $this->api = $api;
+    }
+    public function index() {
+        $page_title = "Administration";
+        $page_description = "Tableau de bord modérateur";
+
+        if (!$this->api->isLoggedIn()) {
+            $_SESSION['redirect_after_login'] = 'index.php?route=admin';
+            header('Location: index.php?route=login');
+            exit();
+        }
+        if (!$this->api->isModerator()) {
+            $_SESSION['flash_message'] = "Accès réservé aux modérateurs.";
+            $_SESSION['flash_type'] = "error";
+            header('Location: index.php');
+            exit();
+        }
+
+        try {
+            $stats = calculate_forum_stats($this->api);
+        } catch (Exception $e) {
+            $stats = [];
+        }
+
+        $users = $articles = $threads = $comments = [];
+        try { $users = $this->api->request('/admin/users?limit=5', 'GET', [], true); } catch (Exception $e) {}
+        try { $articles = $this->api->request('/admin/articles?limit=5', 'GET', [], true); } catch (Exception $e) {}
+        try { $threads = $this->api->request('/admin/threads?limit=5', 'GET', [], true); } catch (Exception $e) {}
+        try { $comments = $this->api->request('/admin/comments?limit=5', 'GET', [], true); } catch (Exception $e) {}
+
+        require __DIR__ . '/../views/templates/header.php';
+        require __DIR__ . '/../views/admin/dashboard.php';
+        require __DIR__ . '/../views/templates/footer.php';
+    }
+}
+?>

--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ require_once 'api.php';
 $route = isset($_GET['route']) ? sanitize_string($_GET['route']) : 'home';
 
 // Whitelist allowed routes to avoid path traversal
-$allowed_routes = ['home','article','articles','forums','contact','login','register','new-article','new-thread','about','charte','terms','privacy','dev','cyber-securite','members'];
+$allowed_routes = ['home','article','articles','forums','contact','login','register','new-article','new-thread','about','charte','terms','privacy','dev','cyber-securite','members','admin'];
 $route = in_array($route, $allowed_routes, true) ? $route : 'home';
 
 switch ($route) {
@@ -69,6 +69,11 @@ switch ($route) {
     case 'members':
         require_once __DIR__ . '/controllers/MembersController.php';
         $controller = new MembersController($api);
+        $controller->index();
+        break;
+    case 'admin':
+        require_once __DIR__ . '/controllers/AdminController.php';
+        $controller = new AdminController($api);
         $controller->index();
         break;
     case 'about':

--- a/views/admin/dashboard.php
+++ b/views/admin/dashboard.php
@@ -1,0 +1,108 @@
+<!-- Page Header -->
+<div class="page-header" style="background-color: var(--near-black); padding: 2rem 0;">
+    <div class="container">
+        <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
+            <a href="index.php" style="color: #999;">Accueil</a> &raquo; Administration
+        </div>
+        <h1 style="color: var(--white); margin-bottom: 0.5rem;">Tableau de bord</h1>
+        <p style="color: #ccc; max-width: 700px;">Outils de modération et statistiques du forum.</p>
+    </div>
+</div>
+
+<!-- Main Content -->
+<main class="main-content section">
+    <div class="container">
+        <?php if (!empty($stats)): ?>
+        <div class="grid grid-4" style="margin-bottom: 2rem;">
+            <div class="stat-card">
+                <div class="stat-value"><?php echo $stats['user_count']; ?></div>
+                <div class="stat-label">Utilisateurs</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value"><?php echo $stats['article_count']; ?></div>
+                <div class="stat-label">Articles</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value"><?php echo $stats['thread_count']; ?></div>
+                <div class="stat-label">Sujets</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value"><?php echo $stats['reply_count']; ?></div>
+                <div class="stat-label">Réponses</div>
+            </div>
+        </div>
+        <?php endif; ?>
+
+        <h2 style="margin-top:2rem;">Utilisateurs récents</h2>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>ID</th><th>Pseudo</th><th>Email</th></tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($users as $u): ?>
+                    <tr>
+                        <td><?php echo $u['id']; ?></td>
+                        <td><?php echo htmlspecialchars($u['username']); ?></td>
+                        <td><?php echo htmlspecialchars($u['email']); ?></td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+
+        <h2 style="margin-top:2rem;">Articles récents</h2>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>ID</th><th>Titre</th><th>Auteur</th></tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($articles as $a): ?>
+                    <tr>
+                        <td><?php echo $a['id']; ?></td>
+                        <td><a href="index.php?route=article&amp;id=<?php echo $a['id']; ?>"><?php echo htmlspecialchars($a['title']); ?></a></td>
+                        <td><?php echo get_username($a); ?></td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+
+        <h2 style="margin-top:2rem;">Derniers sujets</h2>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>ID</th><th>Titre</th><th>Auteur</th></tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($threads as $t): ?>
+                    <tr>
+                        <td><?php echo $t['id']; ?></td>
+                        <td><a href="thread.php?id=<?php echo $t['id']; ?>"><?php echo htmlspecialchars($t['title']); ?></a></td>
+                        <td><?php echo get_username($t); ?></td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+
+        <h2 style="margin-top:2rem;">Commentaires récents</h2>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr><th>ID</th><th>Auteur</th><th>Contenu</th></tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($comments as $c): ?>
+                    <tr>
+                        <td><?php echo $c['id']; ?></td>
+                        <td><?php echo get_username($c); ?></td>
+                        <td><?php echo substr(strip_tags($c['content'] ?? ''),0,80); ?></td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</main>

--- a/views/templates/header.php
+++ b/views/templates/header.php
@@ -71,6 +71,11 @@ global $api;
                             <a href="new-article.php">
                                 <i class="fas fa-pen"></i> Créer un Article
                             </a>
+                            <?php if ($api->isModerator()): ?>
+                            <a href="index.php?route=admin">
+                                <i class="fas fa-tools"></i> Dashboard
+                            </a>
+                            <?php endif; ?>
                             <a href="logout.php">
                                 <i class="fas fa-sign-out-alt"></i> Déconnexion
                             </a>


### PR DESCRIPTION
## Summary
- implement moderator checks in `api.php`
- add AdminController and dashboard view
- show Dashboard link for moderators only
- add new admin route in index.php
- style stat cards

## Testing
- `php -l api.php`
- `php -l controllers/AdminController.php`
- `php -l views/admin/dashboard.php`
- `php -l views/templates/header.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68708a5331c88332a929d419ed56bf72