### PR TITLE
Make table creation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Start the API with `uvicorn`:
 uvicorn backend.main:app --reload --host 0.0.0.0
 ```
 
+The application no longer creates database tables automatically. Make sure
+the schema exists beforehand (for example using migrations). Set the
+`AUTO_CREATE_TABLES` environment variable to `1` if you still want the API to
+attempt table creation on startup.
+
 The API will be available on port **8000** of the container. Replace
 `<container-ip>` with the actual address of your container, e.g.
 `http://<container-ip>:8000`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,8 +21,13 @@ import feedparser
 from . import models, schemas
 from .database import Base, engine, get_db
 
-# Create database tables if they don't exist
-Base.metadata.create_all(bind=engine)
+# Database tables should be created separately (e.g. via migrations).
+# The application no longer attempts to auto-create them on startup to
+# avoid permission errors when the connected user lacks CREATE privileges.
+# If automatic creation is still desired, set the environment variable
+# ``AUTO_CREATE_TABLES`` to ``1``.
+if os.getenv("AUTO_CREATE_TABLES") == "1":
+    Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Kopo Forum API")
 


### PR DESCRIPTION
## Summary
- allow disabling automatic table creation with environment variable
- mention this new option in the README

## Testing
- `python -m py_compile backend/main.py backend/database.py backend/models.py backend/schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_68708de617ac83329498e7a0ab8e7ecb