### PR TITLE
Add moderation admin pages

### DIFF
--- a/admin/articles.php
+++ b/admin/articles.php
@@ -1,0 +1,7 @@
+<?php
+require_once '../config.php';
+require_once '../functions.php';
+require_once '../api.php';
+require_once __DIR__ . '/../controllers/AdminArticlesController.php';
+$controller = new AdminArticlesController($api);
+$controller->index();

--- a/admin/threads.php
+++ b/admin/threads.php
@@ -1,0 +1,7 @@
+<?php
+require_once '../config.php';
+require_once '../functions.php';
+require_once '../api.php';
+require_once __DIR__ . '/../controllers/AdminThreadsController.php';
+$controller = new AdminThreadsController($api);
+$controller->index();

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,0 +1,7 @@
+<?php
+require_once '../config.php';
+require_once '../functions.php';
+require_once '../api.php';
+require_once __DIR__ . '/../controllers/AdminUsersController.php';
+$controller = new AdminUsersController($api);
+$controller->index();

--- a/controllers/AdminArticlesController.php
+++ b/controllers/AdminArticlesController.php
@@ -1,0 +1,63 @@
+<?php
+class AdminArticlesController {
+    private $api;
+    public function __construct($api) {
+        $this->api = $api;
+    }
+    public function index() {
+        $page_title = "Gestion des articles";
+        $page_description = "Administrer les articles publiés";
+
+        if (!$this->api->isLoggedIn()) {
+            $_SESSION['redirect_after_login'] = 'admin/articles.php';
+            header('Location: ../index.php?route=login');
+            exit();
+        }
+        if (!$this->api->isModerator()) {
+            $_SESSION['flash_message'] = "Accès réservé aux modérateurs.";
+            $_SESSION['flash_type'] = "error";
+            header('Location: ../index.php');
+            exit();
+        }
+
+        $error = '';
+        $success = '';
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_token'] ?? '')) {
+            $action = sanitize_string($_POST['action'] ?? '');
+            $id = isset($_POST['id']) ? sanitize_int($_POST['id']) : null;
+            try {
+                if ($action === 'delete' && $id) {
+                    $this->api->request('/admin/articles/' . $id, 'DELETE', [], true);
+                    $success = "Article supprimé.";
+                } elseif ($action === 'edit' && $id) {
+                    $title = sanitize_string($_POST['title'] ?? '');
+                    $content = sanitize_string($_POST['content'] ?? '');
+                    $is_pub = isset($_POST['is_pub']);
+                    $this->api->request('/articles/' . $id, 'PATCH', [
+                        'title' => $title,
+                        'content' => $content,
+                        'is_pub' => $is_pub
+                    ], true);
+                    $success = "Article mis à jour.";
+                }
+            } catch (Exception $e) {
+                $error = $e->getMessage();
+            }
+        }
+
+        try {
+            $articles = $this->api->request('/admin/articles?limit=100', 'GET', [], true);
+        } catch (Exception $e) {
+            $articles = [];
+            if (empty($error)) {
+                $error = $e->getMessage();
+            }
+        }
+
+        require __DIR__ . '/../views/templates/header.php';
+        require __DIR__ . '/../views/admin/articles.php';
+        require __DIR__ . '/../views/templates/footer.php';
+    }
+}
+?>

--- a/controllers/AdminThreadsController.php
+++ b/controllers/AdminThreadsController.php
@@ -1,0 +1,61 @@
+<?php
+class AdminThreadsController {
+    private $api;
+    public function __construct($api) {
+        $this->api = $api;
+    }
+    public function index() {
+        $page_title = "Gestion des discussions";
+        $page_description = "Administrer les sujets du forum";
+
+        if (!$this->api->isLoggedIn()) {
+            $_SESSION['redirect_after_login'] = 'admin/threads.php';
+            header('Location: ../index.php?route=login');
+            exit();
+        }
+        if (!$this->api->isModerator()) {
+            $_SESSION['flash_message'] = "Accès réservé aux modérateurs.";
+            $_SESSION['flash_type'] = "error";
+            header('Location: ../index.php');
+            exit();
+        }
+
+        $error = '';
+        $success = '';
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_token'] ?? '')) {
+            $action = sanitize_string($_POST['action'] ?? '');
+            $id = isset($_POST['id']) ? sanitize_int($_POST['id']) : null;
+            try {
+                if ($action === 'delete' && $id) {
+                    $this->api->request('/admin/threads/' . $id, 'DELETE', [], true);
+                    $success = "Discussion supprimée.";
+                } elseif ($action === 'edit' && $id) {
+                    $title = sanitize_string($_POST['title'] ?? '');
+                    $content = sanitize_string($_POST['content'] ?? '');
+                    $this->api->request('/forum/threads/' . $id, 'PATCH', [
+                        'title' => $title,
+                        'content' => $content
+                    ], true);
+                    $success = "Discussion mise à jour.";
+                }
+            } catch (Exception $e) {
+                $error = $e->getMessage();
+            }
+        }
+
+        try {
+            $threads = $this->api->request('/admin/threads?limit=100', 'GET', [], true);
+        } catch (Exception $e) {
+            $threads = [];
+            if (empty($error)) {
+                $error = $e->getMessage();
+            }
+        }
+
+        require __DIR__ . '/../views/templates/header.php';
+        require __DIR__ . '/../views/admin/threads.php';
+        require __DIR__ . '/../views/templates/footer.php';
+    }
+}
+?>

--- a/controllers/AdminUsersController.php
+++ b/controllers/AdminUsersController.php
@@ -1,0 +1,63 @@
+<?php
+class AdminUsersController {
+    private $api;
+    public function __construct($api) {
+        $this->api = $api;
+    }
+    public function index() {
+        $page_title = "Gestion des utilisateurs";
+        $page_description = "Administrer les comptes utilisateurs";
+
+        if (!$this->api->isLoggedIn()) {
+            $_SESSION['redirect_after_login'] = 'admin/users.php';
+            header('Location: ../index.php?route=login');
+            exit();
+        }
+        if (!$this->api->isModerator()) {
+            $_SESSION['flash_message'] = "Accès réservé aux modérateurs.";
+            $_SESSION['flash_type'] = "error";
+            header('Location: ../index.php');
+            exit();
+        }
+
+        $error = '';
+        $success = '';
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && verify_csrf_token($_POST['csrf_token'] ?? '')) {
+            $action = sanitize_string($_POST['action'] ?? '');
+            $id = isset($_POST['id']) ? sanitize_int($_POST['id']) : null;
+            try {
+                if ($action === 'delete' && $id) {
+                    $this->api->request('/admin/users/' . $id, 'DELETE', [], true);
+                    $success = "Utilisateur supprimé.";
+                } elseif ($action === 'edit' && $id) {
+                    $username = sanitize_string($_POST['username'] ?? '');
+                    $email = filter_var($_POST['email'] ?? '', FILTER_SANITIZE_EMAIL);
+                    $is_active = isset($_POST['is_active']);
+                    $this->api->request('/users/' . $id, 'PATCH', [
+                        'username' => $username,
+                        'email' => $email,
+                        'is_active' => $is_active
+                    ], true);
+                    $success = "Utilisateur mis à jour.";
+                }
+            } catch (Exception $e) {
+                $error = $e->getMessage();
+            }
+        }
+
+        try {
+            $users = $this->api->request('/admin/users?limit=100', 'GET', [], true);
+        } catch (Exception $e) {
+            $users = [];
+            if (empty($error)) {
+                $error = $e->getMessage();
+            }
+        }
+
+        require __DIR__ . '/../views/templates/header.php';
+        require __DIR__ . '/../views/admin/users.php';
+        require __DIR__ . '/../views/templates/footer.php';
+    }
+}
+?>

--- a/views/admin/articles.php
+++ b/views/admin/articles.php
@@ -1,0 +1,91 @@
+<div class="page-header" style="background-color: var(--near-black); padding: 2rem 0;">
+    <div class="container">
+        <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
+            <a href="../index.php" style="color: #999;">Accueil</a> &raquo;
+            <a href="../index.php?route=admin" style="color: #999;">Administration</a> &raquo;
+            Articles
+        </div>
+        <h1 style="color: var(--white); margin-bottom: 0.5rem;">Gestion des articles</h1>
+        <p style="color: #ccc; max-width: 700px;">Modifier ou supprimer les articles publiés.</p>
+    </div>
+</div>
+
+<main class="main-content section">
+    <div class="container" style="max-width: 900px;">
+        <?php if (!empty($success)): ?>
+            <div class="notification notification-success">
+                <i class="fas fa-check-circle"></i>
+                <?php echo htmlspecialchars($success); ?>
+            </div>
+        <?php endif; ?>
+        <?php if (!empty($error)): ?>
+            <div class="notification notification-error">
+                <i class="fas fa-exclamation-circle"></i>
+                <?php echo htmlspecialchars($error); ?>
+            </div>
+        <?php endif; ?>
+
+        <div class="forum-container">
+            <div class="forum-header">
+                <h2 style="color:var(--white);margin:0;">Articles</h2>
+            </div>
+            <div style="padding:2rem;">
+                <?php if (!empty($articles)): ?>
+                <table style="width:100%;">
+                    <thead>
+                        <tr><th>ID</th><th>Titre</th><th>Auteur</th><th>Publié</th><th style="text-align:center;">Actions</th></tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($articles as $a): ?>
+                            <?php if (isset($_GET['edit']) && intval($_GET['edit']) === $a['id']): ?>
+                                <tr>
+                                    <td colspan="5">
+                                        <form method="post" action="articles.php?edit=<?php echo $a['id']; ?>">
+                                            <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+                                            <input type="hidden" name="action" value="edit">
+                                            <input type="hidden" name="id" value="<?php echo $a['id']; ?>">
+                                            <div class="form-group">
+                                                <label class="form-label">Titre</label>
+                                                <input type="text" name="title" class="form-control" value="<?php echo htmlspecialchars($a['title']); ?>" required>
+                                            </div>
+                                            <div class="form-group">
+                                                <label class="form-label">Contenu</label>
+                                                <textarea name="content" class="form-control" rows="6" required><?php echo htmlspecialchars($a['content']); ?></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label class="form-label"><input type="checkbox" name="is_pub" <?php echo !empty($a['is_pub']) ? 'checked' : ''; ?>> Publié</label>
+                                            </div>
+                                            <div style="margin-top:1rem;">
+                                                <button type="submit" class="btn btn-primary">Enregistrer</button>
+                                                <a href="articles.php" class="btn btn-outline">Annuler</a>
+                                            </div>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php else: ?>
+                                <tr>
+                                    <td><?php echo $a['id']; ?></td>
+                                    <td><?php echo htmlspecialchars($a['title']); ?></td>
+                                    <td><?php echo get_username($a); ?></td>
+                                    <td><?php echo !empty($a['is_pub']) ? 'Oui' : 'Non'; ?></td>
+                                    <td style="text-align:center;">
+                                        <a href="articles.php?edit=<?php echo $a['id']; ?>" class="btn btn-outline btn-sm">Éditer</a>
+                                        <form method="post" action="articles.php" style="display:inline-block;">
+                                            <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?php echo $a['id']; ?>">
+                                            <button type="submit" class="btn btn-outline btn-sm" onclick="return confirm('Supprimer cet article ?');" style="color:var(--accent-red);border-color:var(--accent-red);">Supprimer</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <?php else: ?>
+                    <p>Aucun article disponible.</p>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</main>

--- a/views/admin/dashboard.php
+++ b/views/admin/dashboard.php
@@ -33,6 +33,9 @@
         </div>
         <?php endif; ?>
         <div class="admin-links" style="margin-bottom:2rem;">
+            <a href="../admin/users.php" class="btn btn-secondary">Gérer les utilisateurs</a>
+            <a href="../admin/articles.php" class="btn btn-secondary">Gérer les articles</a>
+            <a href="../admin/threads.php" class="btn btn-secondary">Gérer les sujets</a>
             <a href="../admin/categories.php" class="btn btn-secondary">Gérer les catégories</a>
         </div>
 

--- a/views/admin/threads.php
+++ b/views/admin/threads.php
@@ -1,0 +1,87 @@
+<div class="page-header" style="background-color: var(--near-black); padding: 2rem 0;">
+    <div class="container">
+        <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
+            <a href="../index.php" style="color: #999;">Accueil</a> &raquo;
+            <a href="../index.php?route=admin" style="color: #999;">Administration</a> &raquo;
+            Discussions
+        </div>
+        <h1 style="color: var(--white); margin-bottom: 0.5rem;">Gestion des discussions</h1>
+        <p style="color: #ccc; max-width: 700px;">Modifier ou supprimer les sujets du forum.</p>
+    </div>
+</div>
+
+<main class="main-content section">
+    <div class="container" style="max-width: 900px;">
+        <?php if (!empty($success)): ?>
+            <div class="notification notification-success">
+                <i class="fas fa-check-circle"></i>
+                <?php echo htmlspecialchars($success); ?>
+            </div>
+        <?php endif; ?>
+        <?php if (!empty($error)): ?>
+            <div class="notification notification-error">
+                <i class="fas fa-exclamation-circle"></i>
+                <?php echo htmlspecialchars($error); ?>
+            </div>
+        <?php endif; ?>
+
+        <div class="forum-container">
+            <div class="forum-header">
+                <h2 style="color:var(--white);margin:0;">Discussions</h2>
+            </div>
+            <div style="padding:2rem;">
+                <?php if (!empty($threads)): ?>
+                <table style="width:100%;">
+                    <thead>
+                        <tr><th>ID</th><th>Titre</th><th>Auteur</th><th style="text-align:center;">Actions</th></tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($threads as $t): ?>
+                            <?php if (isset($_GET['edit']) && intval($_GET['edit']) === $t['id']): ?>
+                                <tr>
+                                    <td colspan="4">
+                                        <form method="post" action="threads.php?edit=<?php echo $t['id']; ?>">
+                                            <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+                                            <input type="hidden" name="action" value="edit">
+                                            <input type="hidden" name="id" value="<?php echo $t['id']; ?>">
+                                            <div class="form-group">
+                                                <label class="form-label">Titre</label>
+                                                <input type="text" name="title" class="form-control" value="<?php echo htmlspecialchars($t['title']); ?>" required>
+                                            </div>
+                                            <div class="form-group">
+                                                <label class="form-label">Contenu</label>
+                                                <textarea name="content" class="form-control" rows="6" required><?php echo htmlspecialchars($t['content']); ?></textarea>
+                                            </div>
+                                            <div style="margin-top:1rem;">
+                                                <button type="submit" class="btn btn-primary">Enregistrer</button>
+                                                <a href="threads.php" class="btn btn-outline">Annuler</a>
+                                            </div>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php else: ?>
+                                <tr>
+                                    <td><?php echo $t['id']; ?></td>
+                                    <td><?php echo htmlspecialchars($t['title']); ?></td>
+                                    <td><?php echo get_username($t); ?></td>
+                                    <td style="text-align:center;">
+                                        <a href="threads.php?edit=<?php echo $t['id']; ?>" class="btn btn-outline btn-sm">Éditer</a>
+                                        <form method="post" action="threads.php" style="display:inline-block;">
+                                            <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?php echo $t['id']; ?>">
+                                            <button type="submit" class="btn btn-outline btn-sm" onclick="return confirm('Supprimer cette discussion ?');" style="color:var(--accent-red);border-color:var(--accent-red);">Supprimer</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <?php else: ?>
+                    <p>Aucune discussion disponible.</p>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</main>

--- a/views/admin/users.php
+++ b/views/admin/users.php
@@ -1,0 +1,91 @@
+<div class="page-header" style="background-color: var(--near-black); padding: 2rem 0;">
+    <div class="container">
+        <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
+            <a href="../index.php" style="color: #999;">Accueil</a> &raquo;
+            <a href="../index.php?route=admin" style="color: #999;">Administration</a> &raquo;
+            Utilisateurs
+        </div>
+        <h1 style="color: var(--white); margin-bottom: 0.5rem;">Gestion des utilisateurs</h1>
+        <p style="color: #ccc; max-width: 700px;">Ajouter, éditer ou supprimer les comptes utilisateurs.</p>
+    </div>
+</div>
+
+<main class="main-content section">
+    <div class="container" style="max-width: 900px;">
+        <?php if (!empty($success)): ?>
+            <div class="notification notification-success">
+                <i class="fas fa-check-circle"></i>
+                <?php echo htmlspecialchars($success); ?>
+            </div>
+        <?php endif; ?>
+        <?php if (!empty($error)): ?>
+            <div class="notification notification-error">
+                <i class="fas fa-exclamation-circle"></i>
+                <?php echo htmlspecialchars($error); ?>
+            </div>
+        <?php endif; ?>
+
+        <div class="forum-container">
+            <div class="forum-header">
+                <h2 style="color:var(--white);margin:0;">Utilisateurs enregistrés</h2>
+            </div>
+            <div style="padding:2rem;">
+                <?php if (!empty($users)): ?>
+                <table style="width:100%;">
+                    <thead>
+                        <tr><th>ID</th><th>Pseudo</th><th>Email</th><th>Actif</th><th style="text-align:center;">Actions</th></tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($users as $u): ?>
+                            <?php if (isset($_GET['edit']) && intval($_GET['edit']) === $u['id']): ?>
+                                <tr>
+                                    <td colspan="5">
+                                        <form method="post" action="users.php?edit=<?php echo $u['id']; ?>">
+                                            <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+                                            <input type="hidden" name="action" value="edit">
+                                            <input type="hidden" name="id" value="<?php echo $u['id']; ?>">
+                                            <div class="form-group">
+                                                <label class="form-label">Pseudo</label>
+                                                <input type="text" name="username" class="form-control" value="<?php echo htmlspecialchars($u['username']); ?>" required>
+                                            </div>
+                                            <div class="form-group">
+                                                <label class="form-label">Email</label>
+                                                <input type="email" name="email" class="form-control" value="<?php echo htmlspecialchars($u['email']); ?>" required>
+                                            </div>
+                                            <div class="form-group">
+                                                <label class="form-label"><input type="checkbox" name="is_active" <?php echo !empty($u['is_active']) ? 'checked' : ''; ?>> Actif</label>
+                                            </div>
+                                            <div style="margin-top:1rem;">
+                                                <button type="submit" class="btn btn-primary">Enregistrer</button>
+                                                <a href="users.php" class="btn btn-outline">Annuler</a>
+                                            </div>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php else: ?>
+                                <tr>
+                                    <td><?php echo $u['id']; ?></td>
+                                    <td><?php echo htmlspecialchars($u['username']); ?></td>
+                                    <td><?php echo htmlspecialchars($u['email']); ?></td>
+                                    <td><?php echo !empty($u['is_active']) ? 'Oui' : 'Non'; ?></td>
+                                    <td style="text-align:center;">
+                                        <a href="users.php?edit=<?php echo $u['id']; ?>" class="btn btn-outline btn-sm">Éditer</a>
+                                        <form method="post" action="users.php" style="display:inline-block;">
+                                            <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?php echo $u['id']; ?>">
+                                            <button type="submit" class="btn btn-outline btn-sm" onclick="return confirm('Supprimer cet utilisateur ?');" style="color:var(--accent-red);border-color:var(--accent-red);">Supprimer</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <?php else: ?>
+                    <p>Aucun utilisateur trouvé.</p>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</main>


### PR DESCRIPTION
## Summary
- add AdminUsersController, AdminArticlesController and AdminThreadsController
- create matching admin pages and templates for user, article and thread management
- enhance admin dashboard with links to the new sections

## Testing
- `php -l controllers/AdminUsersController.php`
- `php -l controllers/AdminArticlesController.php`
- `php -l controllers/AdminThreadsController.php`
- `php -l views/admin/users.php`
- `php -l views/admin/articles.php`
- `php -l views/admin/threads.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687095d26cc8833297d6d67416b2a5fa