### PR TITLE
Fix admin includes paths

### DIFF
--- a/admin/articles.php
+++ b/admin/articles.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config.php';
-require_once '../functions.php';
-require_once '../api.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/../api.php';
 require_once __DIR__ . '/../controllers/AdminArticlesController.php';
 $controller = new AdminArticlesController($api);
 $controller->index();

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config.php';
-require_once '../functions.php';
-require_once '../api.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/../api.php';
 require_once __DIR__ . '/../controllers/AdminCategoriesController.php';
 $controller = new AdminCategoriesController($api);
 $controller->index();

--- a/admin/threads.php
+++ b/admin/threads.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config.php';
-require_once '../functions.php';
-require_once '../api.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/../api.php';
 require_once __DIR__ . '/../controllers/AdminThreadsController.php';
 $controller = new AdminThreadsController($api);
 $controller->index();

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config.php';
-require_once '../functions.php';
-require_once '../api.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/../api.php';
 require_once __DIR__ . '/../controllers/AdminUsersController.php';
 $controller = new AdminUsersController($api);
 $controller->index();

--- a/views/templates/header.php
+++ b/views/templates/header.php
@@ -1,6 +1,6 @@
 <?php
-require_once 'config.php';
-require_once 'api.php';
+require_once dirname(__DIR__, 2) . '/config.php';
+require_once dirname(__DIR__, 2) . '/api.php';
 // Access the API instance when included from controllers
 global $api;
 ?>


### PR DESCRIPTION
## Summary
- use `__DIR__` for admin page includes so config loading works regardless of cwd
- load config and API using absolute paths in header template

## Testing
- `php -l admin/articles.php`
- `php -l admin/categories.php`
- `php -l admin/threads.php`
- `php -l admin/users.php`
- `php -l views/templates/header.php`


------
https://chatgpt.com/codex/tasks/task_e_6870a15b87c083329a5ce2ef31f0aeb7