### PR TITLE
Add demo data scripts

### DIFF
--- a/populate_data.sh
+++ b/populate_data.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Remplit la base avec des données de démonstration
+# Usage: bash populate_data.sh [DB_NAME]
+
+set -e
+DB_NAME=${1:-forum}
+
+echo "Insertion des données de démonstration dans $DB_NAME..."
+
+sudo -u postgres psql -d "$DB_NAME" -f populate_demo_data.sql
+
+echo "Données insérées."

--- a/populate_demo_data.sql
+++ b/populate_demo_data.sql
@@ -1,0 +1,514 @@
+-- Insert tags
+INSERT INTO tags (name) VALUES
+    ('humour'),
+    ('demo'),
+    ('cyber'),
+    ('dev')
+ON CONFLICT DO NOTHING;
+
+-- Insert forum categories
+INSERT INTO forum_categories (name, description, order_index) VALUES
+    ('Général', 'Discussions générales', 1),
+    ('Humour', 'Blagues et fun', 2),
+    ('Tech', 'Discussions techniques', 3),
+    ('Projets', 'Vos projets et démos', 4),
+    ('Annonces', 'Annonces officielles', 5)
+ON CONFLICT DO NOTHING;
+
+-- Create demo users
+WITH passwd AS (
+    SELECT '$2b$12$CYXDW5KcsszuVP51iwZtsur8H2t22sPCVfxOOCS5kq4AhdK1adLgm' AS hash
+)
+INSERT INTO users (username, email, pass_hash, bio)
+VALUES
+    ('alice', 'alice@example.com', (SELECT hash FROM passwd), 'Amatrice de café'),
+    ('bob', 'bob@example.com', (SELECT hash FROM passwd), 'Toujours prêt pour une blague'),
+    ('charlie', 'charlie@example.com', (SELECT hash FROM passwd), 'Fan de jeux vidéos'),
+    ('diana', 'diana@example.com', (SELECT hash FROM passwd), 'Geek assumée'),
+    ('edouard', 'ed@example.com', (SELECT hash FROM passwd), 'Collectionneur de GIFs'),
+    ('fatima', 'fatima@example.com', (SELECT hash FROM passwd), 'Amatrice de chansons'),
+    ('gerard', 'gerard@example.com', (SELECT hash FROM passwd), 'Collectionne les calembours'),
+    ('helene', 'helene@example.com', (SELECT hash FROM passwd), 'Toujours connectée'),
+    ('igor', 'igor@example.com', (SELECT hash FROM passwd), 'Hacker en herbe'),
+    ('julie', 'julie@example.com', (SELECT hash FROM passwd), 'Adepte des mèmes');
+
+-- Assign user role to all new users
+INSERT INTO user_roles (user_id, role_id)
+SELECT id, (SELECT id FROM roles WHERE name='user') FROM users WHERE username IN
+    ('alice','bob','charlie','diana','edouard','fatima','gerard','helene','igor','julie');
+
+-- Demo articles with humour or demo tags
+INSERT INTO articles (user_id, title, content, is_pub)
+VALUES
+    ((SELECT id FROM users WHERE username='alice'), 'Blague du jour', $$Pourquoi les devs aiment-ils les canards en plastique ? Pour déboguer !$$, TRUE),
+    ((SELECT id FROM users WHERE username='bob'), 'Mon premier script', $$Voici comment j'ai écris un script qui me rappelle de boire de l'eau.$$, TRUE),
+    ((SELECT id FROM users WHERE username='charlie'), 'La fois où j''ai cassé la prod', $$C'était un mardi, tout le monde s'en souvient encore...$$, TRUE),
+    ((SELECT id FROM users WHERE username='diana'), 'Astuce terminal', $$Tapez `fortune | cowsay` pour une vache philosophe.$$, TRUE),
+    ((SELECT id FROM users WHERE username='edouard'), 'Demo incroyable', $$Je vous montre comment ne pas paniquer quand rien ne marche.$$, TRUE);
+
+-- Tag demo articles
+INSERT INTO article_tags (article_id, tag_id)
+SELECT a.id, t.id FROM articles a JOIN tags t ON t.name IN ('humour','demo')
+WHERE a.title IN ('Blague du jour','Mon premier script','La fois où j''ai cassé la prod','Astuce terminal','Demo incroyable');
+
+-- Comments on demo articles
+INSERT INTO comments (post_id, user_id, content)
+VALUES
+    ((SELECT id FROM articles WHERE title='Blague du jour'), (SELECT id FROM users WHERE username='bob'), 'Haha, pas mal !'),
+    ((SELECT id FROM articles WHERE title='Blague du jour'), (SELECT id FROM users WHERE username='charlie'), 'Je vais la ressortir celle-là.'),
+    ((SELECT id FROM articles WHERE title='Mon premier script'), (SELECT id FROM users WHERE username='alice'), 'Pense à ajouter un `set -e` la prochaine fois.'),
+    ((SELECT id FROM articles WHERE title='La fois où j''ai cassé la prod'), (SELECT id FROM users WHERE username='diana'), 'On a tous vécu ça un jour.'),
+    ((SELECT id FROM articles WHERE title='Astuce terminal'), (SELECT id FROM users WHERE username='edouard'), 'Génial, merci pour le tip !');
+
+-- Forum threads
+INSERT INTO forum_threads (user_id, category_id, title, content)
+VALUES
+    ((SELECT id FROM users WHERE username='bob'), (SELECT id FROM forum_categories WHERE name='Humour'), 'Votre blague préférée', 'Partagez vos meilleures blagues ici !'),
+    ((SELECT id FROM users WHERE username='charlie'), (SELECT id FROM forum_categories WHERE name='Tech'), 'Choisir son éditeur', 'Vim contre Emacs, le duel éternel.'),
+    ((SELECT id FROM users WHERE username='diana'), (SELECT id FROM forum_categories WHERE name='Projets'), 'Mon site perso', 'J''ai enfin terminé ma page d''accueil !'),
+    ((SELECT id FROM users WHERE username='igor'), (SELECT id FROM forum_categories WHERE name='Général'), 'Café ou thé ?', 'Le débat qui divise.');
+
+-- Replies to threads
+INSERT INTO forum_replies (thread_id, user_id, content)
+VALUES
+    ((SELECT id FROM forum_threads WHERE title='Votre blague préférée'), (SELECT id FROM users WHERE username='alice'), 'Un 0 rencontre un 8 : bel anneau !'),
+    ((SELECT id FROM forum_threads WHERE title='Votre blague préférée'), (SELECT id FROM users WHERE username='julie'), 'Pourquoi les canards ?'),
+    ((SELECT id FROM forum_threads WHERE title='Choisir son éditeur'), (SELECT id FROM users WHERE username='edouard'), 'Nano pour la vie !'),
+    ((SELECT id FROM forum_threads WHERE title='Mon site perso'), (SELECT id FROM users WHERE username='bob'), 'Hâte de voir ça.'),
+    ((SELECT id FROM forum_threads WHERE title='Café ou thé ?'), (SELECT id FROM users WHERE username='charlie'), 'Café, évidemment.');
+
+-- Provided articles by admin with tags
+INSERT INTO articles (user_id, title, content, is_pub) VALUES
+    ((SELECT id FROM users WHERE username='admin'), 'Pourquoi les audits de sécurité échouent (souvent)', $$
+L’audit de sécurité est un outil essentiel pour toute organisation soucieuse de son intégrité numérique. Il est censé révéler les vulnérabilités, cartographier les risques, et guider les décisions stratégiques pour améliorer la posture de sécurité. Pourtant, dans la réalité du terrain, un grand nombre d’audits échouent. Pas nécessairement dans leur exécution technique, mais dans leur utilité réelle. Ils ne déclenchent aucun changement concret, ne sont pas compris, ou pire : renforcent un faux sentiment de sécurité.
+
+Pourquoi ? Il ne suffit pas de pointer du doigt des failles techniques pour provoquer une amélioration. Ce sont souvent des éléments organisationnels, humains et structurels qui sabotent leur efficacité.
+
+## 1. Des attentes irréalistes dès le départ
+
+L’un des premiers problèmes vient de la manière dont l’audit est perçu. Beaucoup de décideurs attendent de cet exercice **une validation globale de la sécurité**, voire un tampon de conformité à présenter à la direction ou aux partenaires.
+
+Cela crée une distorsion profonde :
+- **Les auditeurs sont perçus comme des vérificateurs** de conformité ou des contrôleurs qualité, alors que leur rôle devrait être plus consultatif, plus proche du diagnostic.
+- **Les résultats sont interprétés comme une note**, un bulletin de santé, alors qu’il s’agit avant tout d’un état des lieux partiel, dans un contexte donné.
+
+L'audit ne garantit pas l'absence de failles. Il ne garantit même pas qu'il a tout vu.
+
+## 2. Un périmètre mal défini ou trop restreint
+
+Un autre facteur d’échec réside dans la **définition du périmètre**. Trop souvent :
+- Certaines briques sensibles sont **volontairement exclues** de l’audit ("pas encore en production", "trop critique pour être testé", etc.).
+- Les environnements audités ne sont **pas représentatifs** : environnement de test trop propre, utilisateurs fictifs, règles de pare-feu désactivées.
+- On oublie **les dépendances externes** : APIs tierces, fournisseurs SaaS, connexions inter-entreprises.
+
+Le résultat ? L’audit ne donne qu’une **vision tronquée** de la surface d’attaque réelle. Et lorsqu'une attaque survient plus tard, elle se produit bien souvent en dehors du périmètre audité.
+
+## 3. La fracture entre tech et non-tech
+
+L’audit est souvent initié par une **direction non technique** (DSI, RSSI, parfois RH ou conformité). L’intention est bonne, mais cela peut entraîner une série de malentendus :
+- Les objectifs de l’audit sont mal formulés : « vérifier si c’est sécurisé » ne veut rien dire concrètement.
+- Les interlocuteurs ne comprennent pas toujours la nature ou la gravité des découvertes.
+- Les développeurs ou responsables infra voient parfois les auditeurs comme **des intrus**, voire des critiques malvenus qui pointent des problèmes sans comprendre les contraintes du quotidien.
+
+Résultat : **pas d’appropriation** des conclusions. Le rapport finit dans un dossier partagé, sans suite.
+
+## 4. Un rapport qui n’est pas actionnable
+
+Un audit peut être techniquement excellent et pourtant totalement inutile s’il se termine par un rapport :
+- Trop long, trop dense, illisible.
+- Trop flou : "le chiffrement doit être amélioré" sans dire comment ni pourquoi.
+- Sans priorisation claire : une vulnérabilité critique noyée dans une mer de remarques mineures.
+- Sans plan d’action : pas d’indication concrète sur ce qui doit être corrigé, par qui, ni dans quel délai.
+
+Sans **traduction opérationnelle**, le rapport reste une photographie figée, et non un outil de pilotage.
+
+## 5. Un environnement qui ne veut pas changer
+
+Même lorsqu’un audit est bien mené, bien compris, et bien rapporté, **l’échec peut venir après** : au moment de passer à l’action.
+
+Dans certains cas :
+- L’organisation **n’a pas les moyens** (humains, financiers, techniques) de mettre en œuvre les recommandations.
+- Il y a un **refus politique** ou hiérarchique d’admettre la gravité des problèmes.
+- Les risques sont **acceptés par défaut**, sans réelle évaluation ("on n’a jamais eu d’incident, donc ça ira").
+
+Le plus ironique, c’est que **les audits récurrents** deviennent alors un simple rituel : on identifie les mêmes failles chaque année, sans qu’elles ne soient corrigées. L’audit devient un décor.
+
+## 6. Repenser l’audit comme un outil de dialogue
+
+Pour qu’un audit de sécurité ne soit pas un échec, il faut **changer de posture**.
+
+- **Côté commanditaire**, il faut poser des attentes claires, inclure les équipes techniques dès le départ, et exiger un livrable exploitable.
+- **Côté auditeurs**, il faut savoir vulgariser, contextualiser les risques, accompagner les équipes dans la priorisation et la remédiation.
+- **Côté équipes opérationnelles**, il faut accepter que l’audit n’est pas une mise en accusation mais un levier d’amélioration.
+
+L’audit doit être perçu non pas comme un examen final, mais comme **un outil d’introspection**, un révélateur temporaire d’une réalité mouvante. C’est un miroir, pas un jugement.
+
+---
+
+## Conclusion
+
+Un audit de sécurité ne rate pas parce qu’on a mal scanné, ou mal analysé. Il échoue **quand il n’entraîne aucun changement**.
+
+Et si l’on veut qu’il soit un levier de progrès, il faut reconnaître que la sécurité n’est pas seulement affaire de techniques, mais aussi **de culture, d’écoute, de volonté et d’arbitrage**.
+
+Ce n’est qu’en reconnectant les audits aux réalités humaines et organisationnelles qu’ils cesseront d’être un simple rapport oublié, et deviendront un vrai moteur de transformation.
+$$, TRUE),
+    ((SELECT id FROM users WHERE username='admin'), 'La dette technique comme héritage toxique', $$
+Il est courant de présenter la dette technique comme une conséquence naturelle du développement logiciel : un compromis entre livraison rapide et qualité, une couche de poussière qu’on accepte en échange du progrès.
+
+Mais dans la réalité des équipes de développement, la dette technique n’est pas seulement une question de code mal écrit ou de raccourcis techniques. C’est **un héritage**. Un héritage souvent toxique, transmis de sprint en sprint, de développeur en développeur, de génération en génération. Et si l'on ne change pas de culture, ce legs finit par étouffer l'équipe, les projets, et parfois même l'entreprise.
+
+## 1. Comprendre la dette comme une chaîne intergénérationnelle
+
+Chaque commit mal documenté, chaque hack non isolé, chaque architecture contournée sous pression, laisse une trace. Ce sont des décisions que l'on prend **dans l'urgence du présent**, et que **d'autres devront porter** dans le futur.
+
+Les développeurs changent. Les leads tournent. Les prestataires partent. Mais le code, lui, reste. Et avec lui, toutes les **zones d’ombre non transmises**. L’héritage est là : incompréhensible, fragile, et menaçant.
+
+Cette dette-là n’est pas qu’un problème technique. Elle est **humaine et culturelle**. Ce qu’on transmet ou qu’on ne transmet pas. Ce qu’on tolère ou qu’on accepte de faire corriger.
+
+## 2. Pourquoi elle devient toxique
+
+La dette technique devient toxique quand elle **empêche d’évoluer** sans risquer la rupture. Elle devient paralysante, comme un vieux bâtiment dont on a oublié les fondations, mais qu’on continue d’empiler.
+
+Elle empoisonne les équipes :
+- Les nouveaux arrivants passent plus de temps à **comprendre qu’à construire**.
+- Les anciens deviennent **gardiens du temple**, indispensables à cause de leur connaissance des archaïsmes.
+- L’équipe développe un **rapport défensif au code** : on touche le moins possible, on contourne, on duplique.
+
+Et plus grave encore : elle **détruit la motivation**. Rien n’érode plus vite l’envie de bien faire que l’impossibilité de le faire.
+
+## 3. La culture de la dette acceptée
+
+Dans certaines entreprises, la dette technique est devenue **norme implicite**. Elle n’est pas reconnue, elle est minimisée, voire valorisée :  
+> "C’est comme ça qu’on a toujours fait."  
+> "On n’a pas le temps pour des refacto, on a des deadlines."  
+> "On corrigera ça plus tard."
+
+Sauf que **plus tard ne vient jamais**. Et les rares moments où l’on s’autorise une remise à plat sont souvent trop tardifs, trop partiels, ou menés dans la douleur.
+
+Quand la culture d’équipe accepte la dette comme un mal nécessaire permanent, elle renonce à l’amélioration continue. Elle entre dans une spirale de survie.
+
+## 4. Briser le cycle : transmettre autrement
+
+Briser l’héritage toxique, ce n’est pas tout réécrire. C’est **changer notre rapport au temps et à la transmission**. Voici quelques leviers essentiels :
+
+- **Rendre le code explicite** : documentation vivante, code auto-descriptif, standards partagés.
+- **Ne pas cacher les failles** : une dette non nommée est une dette invisible. Il faut la tracer, la visibiliser, la prioriser.
+- **Permettre le refactoring régulier** : le refacto ne doit pas être un luxe, mais un droit de l’équipe.
+- **Transmettre la culture, pas juste le code** : pair programming, revues pédagogiques, onboarding progressif.
+
+La clé est dans **la mémoire d’équipe**. Ce qu’on prend le temps de se dire, ce qu’on écrit, ce qu’on éclaire ensemble.
+
+## 5. Une dette qui devient capital
+
+Et si on transformait notre regard ?  
+La dette technique ne doit pas être uniquement vue comme un poids. Elle peut devenir **un capital narratif** si elle est reconnue, documentée, discutée. Elle raconte les contraintes passées, les choix, les solutions d’urgence.
+
+Mais ce capital n’a de valeur que s’il est **mis au service de la suite**, pas s’il est verrouillé.
+
+---
+
+## Conclusion
+
+La dette technique ne tue pas un projet d’un coup. Elle le **ralentit, l’érode, le rend dépendant**. Et surtout, elle **empoisonne la relève**, si on ne prend pas la peine de lui transmettre autre chose qu’un chantier.
+
+Contenir la dette, c’est d’abord une **décision culturelle** : celle de créer un environnement où le code est compris, discuté, vivant. C’est cette culture qui permet aux générations de devs de **construire ensemble**, plutôt que de **survivre seuls dans les ruines du passé**.
+$$, TRUE),
+    ((SELECT id FROM users WHERE username='admin'), 'Le vrai coût des failles non corrigées', $$
+Dans le monde de la cybersécurité, les vulnérabilités connues mais non corrigées sont une forme de dette invisible. Elles s'accumulent dans les systèmes, les applications, les infrastructures, souvent bien identifiées… mais mises de côté. Pas assez urgentes, pas prioritaires, pas "exploitées dans la nature".
+
+Mais cette inaction a un coût. Et ce coût, bien qu’il ne figure pas immédiatement dans un budget ou un rapport d’incident, est **profondément réel**. Il se manifeste en perte de confiance, en rigidité opérationnelle, en stress accumulé, et parfois, en catastrophe.
+
+## 1. L’illusion de l’inaction raisonnable
+
+"On sait que cette faille existe, mais on n’a pas le temps de la corriger pour l’instant."
+
+Cette phrase est omniprésente dans les équipes IT. Elle paraît pragmatique. Pourtant, elle repose sur un postulat faux : que **ne rien faire ne coûte rien**.
+
+Or, ne rien faire, c’est :
+- Accepter une exposition continue à un risque.
+- Multiplier les dépendances autour d’un point faible.
+- Rendre toute future correction plus complexe (et plus coûteuse).
+
+Ce n’est **pas neutre**, c’est une décision de gestion de risque. Et souvent, c’est une mauvaise décision.
+
+## 2. Des pertes invisibles mais accumulées
+
+Quand une faille est connue mais ignorée, voici ce qu’elle peut coûter **sans jamais qu’un attaquant ne l’exploite** :
+
+- **Du temps** : chaque développeur ou ops qui doit éviter cette zone du code, bricoler autour, ou maintenir un patch temporaire, perd de la vélocité.
+- **De la confiance** : les équipes internes savent que le système est fragile. Elles hésitent à le faire évoluer. Elles se méfient du socle.
+- **Du silence** : certaines personnes cessent de remonter les problèmes, persuadées que rien ne sera fait. Le canal de signalement s’assèche.
+- **Du talent** : les bons profils partent ou s’épuisent dans un environnement où la sécurité est secondaire.
+
+Et surtout, une vulnérabilité ignorée finit par **façonner la culture** : une normalisation de la négligence.
+
+## 3. L'effet boule de neige de l’inaction
+
+Plus une faille reste longtemps non traitée, plus **son coût latent augmente**.
+
+- Elle s’intègre dans les process : "attention, faut pas toucher ce module."
+- Elle devient un frein à l’innovation : impossible d’implémenter une nouvelle fonctionnalité sans la refactoriser d'abord.
+- Elle fragilise les mises à jour : toute évolution devient risquée.
+
+C’est le paradoxe : plus on attend, plus **corriger devient difficile, donc plus on attend**. Le coût perçu de la correction monte… jusqu’au jour où le coût réel de l’inaction explose.
+
+## 4. Et quand ça explose ?
+
+Lorsque la faille est exploitée, le coût devient brutalement visible :
+- Interruption de service, perte de données, rançon, fuite médiatique.
+- Temps humain mobilisé dans l’urgence, nuit et week-end compris.
+- Image de marque entachée, parfois durablement.
+- Responsabilités engagées, sanctions juridiques ou réglementaires.
+
+Et surtout, dans beaucoup de cas :  
+> "On savait qu’elle existait."  
+Ce n’est pas une surprise. C’est une **responsabilité assumée**, ou plutôt évitée.
+
+## 5. La culture de la correction proactive
+
+Il est illusoire de vouloir tout corriger tout de suite. Mais il est dangereux de faire de l’inaction une habitude.
+
+Changer la culture, c’est :
+- Mettre en place une **priorisation continue** des vulnérabilités.
+- Donner du temps aux équipes pour **corriger à froid**, et pas seulement en urgence.
+- Valoriser la **correction** comme un acte d’ingénierie à part entière, pas une punition.
+- Éviter la stigmatisation des signalements : un bug relevé n’est pas une faute, c’est une opportunité.
+
+C’est dans cette dynamique que les failles non corrigées cessent d’être un poids mort, et deviennent **des chantiers d’amélioration continue**.
+
+---
+
+## Conclusion
+
+La plupart des incidents majeurs ne viennent pas de failles inconnues, mais de **failles connues et négligées**. Le vrai coût d’une vulnérabilité non corrigée ne réside pas uniquement dans son potentiel d’exploitation. Il se mesure aussi en **pertes silencieuses**, en **freins invisibles**, et en **fragilité accumulée**.
+
+Ne pas corriger, c’est payer. Lentement, discrètement, jusqu’au jour où la facture devient publique. Et souvent, trop tardive.
+$$, TRUE),
+    ((SELECT id FROM users WHERE username='admin'), 'Du terminal au no-code : la fracture invisible', $$
+Le monde du développement et des outils numériques évolue rapidement. D’un côté, des professionnels expérimentés manient le terminal, les scripts shell, les pipelines CI/CD ou les containers en ligne de commande. D’un autre, une nouvelle génération d’utilisateurs – parfois très compétents – construit des solutions entières en glissant-déposant des blocs dans des interfaces no-code.
+
+Ces deux mondes cohabitent. Parfois même dans les mêmes entreprises. Mais ils ne parlent plus le même langage.  
+Et cette **fracture invisible**, entre maîtrise technique profonde et abstraction complète, redéfinit silencieusement les frontières du métier.
+
+## 1. Le confort de l’abstraction… au prix de l’autonomie
+
+Les outils no-code/low-code ont libéré une part immense de la population non-technique. Ils permettent :
+- De créer des applications sans écrire une ligne de code.
+- De connecter des APIs en quelques clics.
+- De prototyper des workflows ou des dashboards en temps réel.
+
+Ce mouvement est une révolution de productivité. Mais il crée aussi une **dépendance profonde à la couche abstraite**.
+
+Lorsque cette abstraction casse – erreur réseau, latence, API modifiée – l’utilisateur n’a souvent **aucun moyen de diagnostiquer**. Là où un·e développeur·euse peut ouvrir le terminal et inspecter ce qui se passe, l’utilisateur no-code est enfermé dans l’interface.
+
+L'outil devient une **boîte noire**.
+
+## 2. L’écart de culture technique
+
+Travailler dans une console oblige à :
+- Comprendre les flux de données.
+- Manipuler les fichiers, les permissions, les variables d’environnement.
+- Lire des logs, décortiquer des erreurs.
+
+Ces gestes, souvent acquis dans la douleur, construisent une **intuition technique**, une capacité à remonter à la cause racine d’un bug.  
+Cette culture n’est pas meilleure en soi, mais elle donne **des points d’ancrage**.
+
+À l’inverse, le no-code/low-code déplace la complexité hors du champ visible. Le code n’est plus lu, les erreurs sont masquées, les logs absents. Ce décalage génère un **fossé culturel** entre les acteurs techniques et les "builders" visuels.
+
+## 3. La création de silos de compétences
+
+Ce fossé devient structurel lorsque :
+- Les équipes "techniques" n’interviennent que pour débuguer les limites des outils no-code.
+- Les "no-codeurs" construisent des solutions entières… mais sans documentation, sans tests, sans contrôles d'accès.
+- Les échanges se transforment en dépendance hiérarchique : "il faut qu’un dev s’en occupe", "on attend que l’équipe IT le valide".
+
+Ainsi se forment **deux silos parallèles** :
+- L’un maîtrise les fondations mais n’a pas toujours la vélocité.
+- L’autre a la vélocité mais pas les fondations.
+
+Et entre les deux, la communication devient difficile. Les incidents s’accumulent, la maintenance devient floue, la responsabilité se dilue.
+
+## 4. Ce que cela change pour les pros de la tech
+
+Les professionnels techniques doivent aujourd’hui s’adapter à un monde où **ils ne sont plus les seuls à "produire" des outils numériques**.
+
+Cela implique :
+- De mieux comprendre les outils no-code, pour pouvoir les accompagner sans condescendance.
+- D’accepter que l’expertise ne passe plus uniquement par le code.
+- De poser les bonnes limites : sécurité, qualité, maintien dans le temps.
+- De transmettre des réflexes plutôt que du contrôle : "comment penser la résilience", "comment nommer les choses", "comment documenter".
+
+Le rôle du dev devient moins "constructeur exclusif" que **gardien des fondations** et **architecte des systèmes**. Et cela demande une posture nouvelle : pédagogique, souple, mais rigoureuse.
+
+## 5. Vers une convergence ?
+
+La fracture n’est pas inévitable. Beaucoup de profils hybrides émergent :
+- Des développeurs qui intègrent des outils low-code dans leur stack pour aller plus vite.
+- Des profils no-code qui apprennent à lire du JSON, à écrire des scripts simples, ou à explorer une API.
+
+Le futur est sans doute dans **l’hybridation des compétences**, à condition que les outils le permettent, et que la culture d’équipe valorise la montée en compétence mutuelle.
+
+---
+
+## Conclusion
+
+Du terminal au no-code, il ne s’agit pas d’un progrès linéaire. Il s’agit d’un changement d’approche, d’un **glissement culturel profond** dans notre manière de concevoir, maintenir et comprendre les outils numériques.
+
+La fracture invisible qui en résulte n’est pas technique : elle est **humaine**. Et c’est en créant des ponts – pédagogiques, culturels, organisationnels – qu’on pourra en faire une richesse plutôt qu’un obstacle.
+$$, TRUE),
+    ((SELECT id FROM users WHERE username='admin'), 'Qu’est-ce qu’un rootkit, et pourquoi c’est si dur à détecter ?', $$
+Dans l’univers de la cybersécurité, certains mots évoquent immédiatement un danger sournois, persistant, presque invisible. Le terme "rootkit" fait partie de ces noms qui inquiètent même les professionnels les plus aguerris.
+
+Mais qu’est-ce qu’un rootkit exactement ? Pourquoi est-ce une menace si difficile à détecter ? Et comment comprendre ce concept sans plonger dans des explications ultra-techniques ?
+
+Voici une plongée accessible dans l’un des types de malwares les plus discrets et redoutables qui existent.
+
+---
+
+## 1. Un rootkit, c’est quoi ?
+
+Un **rootkit** est un ensemble d’outils ou de techniques conçus pour **masquer la présence d’un logiciel malveillant** sur un système.
+
+Il ne s’agit pas d’un virus en soi, mais plutôt d’un **mécanisme de camouflage**. Le rôle principal du rootkit est de **cacher** : cacher un fichier, un processus, une connexion réseau, une clé de registre, un utilisateur…
+
+Son nom vient de "root" (le compte administrateur sous Unix/Linux) et "kit" (un ensemble d’outils). À l’origine, c’était une boîte à outils permettant à un attaquant ayant obtenu les droits root de **se rendre invisible** pour conserver l’accès au système aussi longtemps que possible.
+
+---
+
+## 2. Comment ça fonctionne (sans jargon inutile)
+
+Imagine un voleur dans une maison, qui non seulement cambriole, mais **repeint les caméras de sécurité** pour qu’on ne le voie pas.  
+Le rootkit, c’est la peinture.
+
+Techniquement, il modifie des **comportements internes du système d’exploitation** pour faire croire que tout est normal :
+- Il fait en sorte que les processus malveillants **n’apparaissent pas** dans le gestionnaire de tâches.
+- Il cache des fichiers dans le système sans qu’ils soient listés.
+- Il intercepte certaines fonctions système pour **falsifier les réponses** (par exemple, une requête pour "afficher tous les fichiers" renvoie une liste… sans les fichiers malveillants).
+
+Certains rootkits opèrent **au niveau utilisateur** (ils manipulent les logiciels standards), d’autres agissent **au niveau noyau** (ils altèrent directement le fonctionnement du système d’exploitation lui-même).
+
+---
+
+## 3. Pourquoi c’est si dur à détecter
+
+Il y a plusieurs raisons pour lesquelles les rootkits sont **extrêmement difficiles à repérer** :
+
+### a) Parce qu’ils contrôlent ce que vous voyez
+
+Un bon rootkit ne se contente pas de cacher un fichier, il modifie les outils censés le détecter. Les antivirus, les commandes système, les logs… tous peuvent être **altérés**. C’est comme si le système mentait sur sa propre réalité.
+
+### b) Parce qu’ils peuvent survivre aux redémarrages
+
+Certains rootkits s’installent dans le **bootloader** ou même le **firmware**, ce qui signifie qu’ils sont lancés **avant même le système d’exploitation**. À ce stade, ils peuvent altérer tout ce qui suit… sans être vus.
+
+### c) Parce qu’ils laissent peu de traces
+
+Contrairement à d'autres malwares, les rootkits **ne provoquent pas toujours de comportement visible**. Pas de pop-ups, pas de ralentissements, pas d’anomalie évidente. Leur but est la discrétion, pas la perturbation.
+
+---
+
+## 4. Pourquoi c’est un cauchemar pour les défenseurs
+
+Les rootkits posent un défi spécifique aux équipes de sécurité :
+- **Les outils classiques échouent** : scanner un système de l’intérieur n’a plus de sens si ce système ment.
+- **L’analyse doit venir de l’extérieur** : on doit démarrer l’ordinateur sur un autre système ou utiliser des outils spécialisés hors du système compromis.
+- **La correction est souvent radicale** : lorsqu’un rootkit est détecté, la solution la plus fiable reste souvent… **la réinstallation complète**.
+
+---
+
+## 5. Est-ce encore une menace aujourd’hui ?
+
+Oui, mais elle a évolué.
+
+Les rootkits "classiques" sont devenus rares, car les systèmes modernes ont renforcé leurs protections (intégrité du noyau, démarrage sécurisé, etc.). Mais l’idée persiste :
+- Dans certains **malwares très avancés**, sponsorisés par des États.
+- Dans certains **logiciels espions**, installés sur des téléphones ou ordinateurs de façon ciblée.
+- Dans des **drivers malveillants**, signés numériquement, qui imitent un comportement système légitime.
+
+Les rootkits ont changé de forme, mais **le concept de dissimulation profonde** reste d’actualité.
+
+---
+
+## Conclusion
+
+Un rootkit, ce n’est pas juste un virus discret. C’est un outil conçu pour **altérer la perception de la réalité informatique**.  
+Il transforme le système en illusion, et c’est cette capacité à **contrôler ce qui est visible** qui le rend si dangereux.
+
+Comprendre les rootkits, c’est comprendre à quel point **la confiance dans un système peut être manipulée**. Et c’est une leçon fondamentale en cybersécurité : ce que vous voyez n’est pas toujours ce qui est.
+$$, TRUE);
+
+-- Tag admin articles
+INSERT INTO article_tags (article_id, tag_id)
+SELECT a.id, t.id FROM articles a JOIN tags t ON (
+    (a.title LIKE 'Pourquoi les audits%' AND t.name='cyber') OR
+    (a.title LIKE 'La dette technique%' AND t.name='dev') OR
+    (a.title LIKE 'Le vrai coût des failles%' AND t.name='cyber') OR
+    (a.title LIKE 'Du terminal au no-code%' AND t.name='dev') OR
+    (a.title LIKE 'Qu’est-ce qu’un rootkit%' AND t.name='cyber')
+);
+
+-- Additional demo users
+WITH passwd AS (
+    SELECT '$2b$12$CYXDW5KcsszuVP51iwZtsur8H2t22sPCVfxOOCS5kq4AhdK1adLgm' AS hash
+)
+INSERT INTO users (username, email, pass_hash, bio) VALUES
+    ('karim', 'karim@example.com', (SELECT hash FROM passwd), 'Fan de hardware'),
+    ('lina', 'lina@example.com', (SELECT hash FROM passwd), 'Amatrice de gifs'),
+    ('marc', 'marc@example.com', (SELECT hash FROM passwd), 'Toujours partant pour un hackathon'),
+    ('noemie', 'noemie@example.com', (SELECT hash FROM passwd), 'Adepte de la doc bien faite'),
+    ('omar', 'omar@example.com', (SELECT hash FROM passwd), 'Roi du quickfix'),
+    ('pauline', 'pauline@example.com', (SELECT hash FROM passwd), 'Maîtresse des regex'),
+    ('quentin', 'quentin@example.com', (SELECT hash FROM passwd), 'Toujours en quête de café'),
+    ('rachel', 'rachel@example.com', (SELECT hash FROM passwd), 'La reine des mèmes'),
+    ('samir', 'samir@example.com', (SELECT hash FROM passwd), 'Bricoleur de circuits'),
+    ('tara', 'tara@example.com', (SELECT hash FROM passwd), 'Addict aux emojis');
+
+INSERT INTO user_roles (user_id, role_id)
+SELECT id, (SELECT id FROM roles WHERE name='user')
+FROM users WHERE username IN
+    ('karim','lina','marc','noemie','omar','pauline','quentin','rachel','samir','tara');
+
+-- More demo articles
+INSERT INTO articles (user_id, title, content, is_pub) VALUES
+    ((SELECT id FROM users WHERE username='gerard'), 'La blague infinie', $$Encore une histoire drôle qui tourne en boucle...$$, TRUE),
+    ((SELECT id FROM users WHERE username='helene'), 'Demo de pipeline CI', $$Je partage ma config magique pour automatiser mes tests.$$, TRUE),
+    ((SELECT id FROM users WHERE username='fatima'), 'Comment j''ai survécu à un merge conflict', $$Spoiler : j''ai presque pleuré.$$ , TRUE),
+    ((SELECT id FROM users WHERE username='pauline'), 'Pourquoi j''aime les regex', $$Parce que c''est puissant, évidemment !$$, TRUE),
+    ((SELECT id FROM users WHERE username='omar'), 'Top 10 des raccourcis clavier', $$À utiliser sans modération.$$ , TRUE);
+
+-- Tag new articles
+INSERT INTO article_tags (article_id, tag_id)
+SELECT a.id, t.id FROM articles a
+JOIN tags t ON t.name IN ('humour','demo')
+WHERE a.title IN (
+    'La blague infinie',
+    'Demo de pipeline CI',
+    'Comment j''ai survécu à un merge conflict',
+    'Pourquoi j''aime les regex',
+    'Top 10 des raccourcis clavier'
+);
+
+-- Comments on new articles
+INSERT INTO comments (post_id, user_id, content) VALUES
+    ((SELECT id FROM articles WHERE title='La blague infinie'), (SELECT id FROM users WHERE username='karim'), 'Je la connaissais déjà !'),
+    ((SELECT id FROM articles WHERE title='Demo de pipeline CI'), (SELECT id FROM users WHERE username='lina'), 'Merci, ça va me servir.'),
+    ((SELECT id FROM articles WHERE title='Comment j''ai survécu à un merge conflict'), (SELECT id FROM users WHERE username='marc'), 'On est tous passés par là.'),
+    ((SELECT id FROM articles WHERE title='Pourquoi j''aime les regex'), (SELECT id FROM users WHERE username='rachel'), 'Je comprends enfin !'),
+    ((SELECT id FROM articles WHERE title='Top 10 des raccourcis clavier'), (SELECT id FROM users WHERE username='tara'), 'Je vais les coller au dessus de mon écran.');
+
+-- Additional forum threads
+INSERT INTO forum_threads (user_id, category_id, title, content) VALUES
+    ((SELECT id FROM users WHERE username='marc'), (SELECT id FROM forum_categories WHERE name='Tech'), 'Python vs JavaScript', 'Quel langage préférez-vous et pourquoi ?'),
+    ((SELECT id FROM users WHERE username='lina'), (SELECT id FROM forum_categories WHERE name='Général'), 'Vos musiques de code ?', 'Partagez vos playlists.'),
+    ((SELECT id FROM users WHERE username='quentin'), (SELECT id FROM forum_categories WHERE name='Humour'), 'Images de chats rigolos', 'Parce qu''on en a jamais assez.');
+
+-- Replies to additional threads
+INSERT INTO forum_replies (thread_id, user_id, content) VALUES
+    ((SELECT id FROM forum_threads WHERE title='Python vs JavaScript'), (SELECT id FROM users WHERE username='pauline'), 'Python, parce que les regex y sont top !'),
+    ((SELECT id FROM forum_threads WHERE title='Python vs JavaScript'), (SELECT id FROM users WHERE username='omar'), 'JavaScript pour moi, plus fun !'),
+    ((SELECT id FROM forum_threads WHERE title='Vos musiques de code ?'), (SELECT id FROM users WHERE username='samir'), 'Je code en écoutant du jazz.'),
+    ((SELECT id FROM forum_threads WHERE title='Vos musiques de code ?'), (SELECT id FROM users WHERE username='noemie'), 'Plutôt lo-fi pour rester concentrée.'),
+    ((SELECT id FROM forum_threads WHERE title='Images de chats rigolos'), (SELECT id FROM users WHERE username='gerard'), 'En voici un avec un chapeau!'),
+    ((SELECT id FROM forum_threads WHERE title='Images de chats rigolos'), (SELECT id FROM users WHERE username='lina'), 'Trop mignon !');
+


### PR DESCRIPTION
## Summary
- add script to populate the database with demo data
- include humour/demo articles and threads with replies
- insert provided admin articles tagged cyber or dev
- add extra users, articles, comments and threads for larger dataset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870a0cfff1083329e352dfa94bc41af