### PR TITLE
Fix admin assets with base URL

### DIFF
--- a/admin/articles.php
+++ b/admin/articles.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config.php';
-require_once '../functions.php';
-require_once '../api.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/../api.php';
 require_once __DIR__ . '/../controllers/AdminArticlesController.php';
 $controller = new AdminArticlesController($api);
 $controller->index();

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config.php';
-require_once '../functions.php';
-require_once '../api.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/../api.php';
 require_once __DIR__ . '/../controllers/AdminCategoriesController.php';
 $controller = new AdminCategoriesController($api);
 $controller->index();

--- a/admin/threads.php
+++ b/admin/threads.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config.php';
-require_once '../functions.php';
-require_once '../api.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/../api.php';
 require_once __DIR__ . '/../controllers/AdminThreadsController.php';
 $controller = new AdminThreadsController($api);
 $controller->index();

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,7 +1,7 @@
 <?php
-require_once '../config.php';
-require_once '../functions.php';
-require_once '../api.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../functions.php';
+require_once __DIR__ . '/../api.php';
 require_once __DIR__ . '/../controllers/AdminUsersController.php';
 $controller = new AdminUsersController($api);
 $controller->index();

--- a/config.php
+++ b/config.php
@@ -6,6 +6,10 @@ define('API_BASE_URL', 'http://192.168.1.180:8000');
 define('SITE_NAME', 'Kopo Forum');
 define('SITE_DESCRIPTION', 'Discussions et Actualités sur l\'Informatique et la Cybersécurité');
 
+// Base URL of the site (set this to the subdirectory where the forum is hosted
+// or '/' if it is at the domain root)
+define('BASE_URL', '/');
+
 // Color Scheme
 define('COLOR_WHITE', '#FFFFFF');
 define('COLOR_LIGHT_GRAY', '#E8E8E8');

--- a/views/admin/articles.php
+++ b/views/admin/articles.php
@@ -1,8 +1,8 @@
 <div class="page-header" style="background-color: var(--near-black); padding: 2rem 0;">
     <div class="container">
         <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
-            <a href="../index.php" style="color: #999;">Accueil</a> &raquo;
-            <a href="../index.php?route=admin" style="color: #999;">Administration</a> &raquo;
+            <a href="<?php echo BASE_URL; ?>index.php" style="color: #999;">Accueil</a> &raquo;
+            <a href="<?php echo BASE_URL; ?>index.php?route=admin" style="color: #999;">Administration</a> &raquo;
             Articles
         </div>
         <h1 style="color: var(--white); margin-bottom: 0.5rem;">Gestion des articles</h1>

--- a/views/admin/categories.php
+++ b/views/admin/categories.php
@@ -1,8 +1,8 @@
 <div class="page-header" style="background-color: var(--near-black); padding: 2rem 0;">
     <div class="container">
         <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
-            <a href="index.php" style="color: #999;">Accueil</a> &raquo;
-            <a href="index.php?route=admin" style="color: #999;">Administration</a> &raquo;
+            <a href="<?php echo BASE_URL; ?>index.php" style="color: #999;">Accueil</a> &raquo;
+            <a href="<?php echo BASE_URL; ?>index.php?route=admin" style="color: #999;">Administration</a> &raquo;
             Catégories
         </div>
         <h1 style="color: var(--white); margin-bottom: 0.5rem;">Gestion des catégories</h1>

--- a/views/admin/dashboard.php
+++ b/views/admin/dashboard.php
@@ -2,7 +2,7 @@
 <div class="page-header" style="background-color: var(--near-black); padding: 2rem 0;">
     <div class="container">
         <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
-            <a href="index.php" style="color: #999;">Accueil</a> &raquo; Administration
+            <a href="<?php echo BASE_URL; ?>index.php" style="color: #999;">Accueil</a> &raquo; Administration
         </div>
         <h1 style="color: var(--white); margin-bottom: 0.5rem;">Tableau de bord</h1>
         <p style="color: #ccc; max-width: 700px;">Outils de modération et statistiques du forum.</p>
@@ -79,7 +79,7 @@
                     <?php foreach ($articles as $a): ?>
                     <tr>
                         <td><?php echo $a['id']; ?></td>
-                        <td><a href="index.php?route=article&amp;id=<?php echo $a['id']; ?>"><?php echo htmlspecialchars($a['title']); ?></a></td>
+                        <td><a href="<?php echo BASE_URL; ?>index.php?route=article&amp;id=<?php echo $a['id']; ?>"><?php echo htmlspecialchars($a['title']); ?></a></td>
                         <td><?php echo get_username($a); ?></td>
                     </tr>
                     <?php endforeach; ?>

--- a/views/admin/threads.php
+++ b/views/admin/threads.php
@@ -1,8 +1,8 @@
 <div class="page-header" style="background-color: var(--near-black); padding: 2rem 0;">
     <div class="container">
         <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
-            <a href="../index.php" style="color: #999;">Accueil</a> &raquo;
-            <a href="../index.php?route=admin" style="color: #999;">Administration</a> &raquo;
+            <a href="<?php echo BASE_URL; ?>index.php" style="color: #999;">Accueil</a> &raquo;
+            <a href="<?php echo BASE_URL; ?>index.php?route=admin" style="color: #999;">Administration</a> &raquo;
             Discussions
         </div>
         <h1 style="color: var(--white); margin-bottom: 0.5rem;">Gestion des discussions</h1>

--- a/views/admin/users.php
+++ b/views/admin/users.php
@@ -1,8 +1,8 @@
 <div class="page-header" style="background-color: var(--near-black); padding: 2rem 0;">
     <div class="container">
         <div class="breadcrumb" style="margin-bottom: 0.5rem; color: #999;">
-            <a href="../index.php" style="color: #999;">Accueil</a> &raquo;
-            <a href="../index.php?route=admin" style="color: #999;">Administration</a> &raquo;
+            <a href="<?php echo BASE_URL; ?>index.php" style="color: #999;">Accueil</a> &raquo;
+            <a href="<?php echo BASE_URL; ?>index.php?route=admin" style="color: #999;">Administration</a> &raquo;
             Utilisateurs
         </div>
         <h1 style="color: var(--white); margin-bottom: 0.5rem;">Gestion des utilisateurs</h1>

--- a/views/pages/about.php
+++ b/views/pages/about.php
@@ -7,7 +7,7 @@
             
             <div style="padding: 2rem; display: flex; flex-wrap: wrap; gap: 2rem;">
                 <div style="flex: 1 1 200px; max-width: 300px;">
-                    <img src="/assets/favicon.ico" alt="Logo Kopo" style="width: 100%; height: auto; border-radius: 8px;">
+                    <img src="<?php echo BASE_URL; ?>assets/favicon.ico" alt="Logo Kopo" style="width: 100%; height: auto; border-radius: 8px;">
                 </div>
                 
                 <div style="flex: 2 1 400px; font-size: 1.1rem; line-height: 1.6;">

--- a/views/templates/header.php
+++ b/views/templates/header.php
@@ -1,6 +1,6 @@
 <?php
-require_once 'config.php';
-require_once 'api.php';
+require_once dirname(__DIR__, 2) . '/config.php';
+require_once dirname(__DIR__, 2) . '/api.php';
 // Access the API instance when included from controllers
 global $api;
 ?>
@@ -12,13 +12,13 @@ global $api;
     <title><?php echo isset($page_title) ? $page_title . ' - ' . SITE_NAME : SITE_NAME; ?></title>
     <meta name="description" content="<?php echo isset($page_description) ? $page_description : SITE_DESCRIPTION; ?>">
     <!-- Favicon -->
-    <link rel="icon" href="assets/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="<?php echo BASE_URL; ?>assets/favicon.ico" type="image/x-icon">
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Merriweather:wght@400;700&display=swap" rel="stylesheet">
     <!-- CSS -->
-    <link rel="stylesheet" href="assets/css/styles.css">
+    <link rel="stylesheet" href="<?php echo BASE_URL; ?>assets/css/styles.css">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <!-- Tagify -->
@@ -29,8 +29,8 @@ global $api;
     <header class="site-header">
         <div class="header-container">
             <div class="logo">
-                <a href="index.php">
-                    <img style="vertical-align: middle;" src="assets/favicon.ico" alt="Kopo Forum Logo">
+                <a href="<?php echo BASE_URL; ?>index.php">
+                    <img style="vertical-align: middle;" src="<?php echo BASE_URL; ?>assets/favicon.ico" alt="Kopo Forum Logo">
                 </a>
                 <button class="mobile-nav-toggle" id="mobile-nav-toggle" aria-label="Toggle navigation">
                     <i class="fas fa-bars"></i>
@@ -39,12 +39,12 @@ global $api;
             
             <nav class="main-nav" id="main-nav">
                 <ul>
-                    <li><a href="index.php" <?php echo !isset($_GET['route']) || $_GET['route'] == 'home' ? 'class="active"' : ''; ?>>Accueil</a></li>
-                    <li><a href="index.php?route=forums" <?php echo isset($_GET['route']) && $_GET['route'] == 'forums' ? 'class="active"' : ''; ?>>Forums</a></li>
-                    <li><a href="index.php?route=articles" <?php echo isset($_GET['route']) && $_GET['route'] == 'articles' ? 'class="active"' : ''; ?>>Articles</a></li>
-                    <li><a href="index.php?route=cyber-securite" <?php echo isset($_GET['route']) && $_GET['route'] == 'cyber-securite' ? 'class="active"' : ''; ?>>Cyber-Sécurité</a></li>
-                    <li><a href="index.php?route=dev" <?php echo isset($_GET['route']) && $_GET['route'] == 'dev' ? 'class="active"' : ''; ?>>Développement</a></li>
-                    <li><a href="index.php?route=members" <?php echo isset($_GET['route']) && $_GET['route'] == 'members' ? 'class="active"' : ''; ?>>Membres</a></li>
+                    <li><a href="<?php echo BASE_URL; ?>index.php" <?php echo !isset($_GET['route']) || $_GET['route'] == 'home' ? 'class="active"' : ''; ?>>Accueil</a></li>
+                    <li><a href="<?php echo BASE_URL; ?>index.php?route=forums" <?php echo isset($_GET['route']) && $_GET['route'] == 'forums' ? 'class="active"' : ''; ?>>Forums</a></li>
+                    <li><a href="<?php echo BASE_URL; ?>index.php?route=articles" <?php echo isset($_GET['route']) && $_GET['route'] == 'articles' ? 'class="active"' : ''; ?>>Articles</a></li>
+                    <li><a href="<?php echo BASE_URL; ?>index.php?route=cyber-securite" <?php echo isset($_GET['route']) && $_GET['route'] == 'cyber-securite' ? 'class="active"' : ''; ?>>Cyber-Sécurité</a></li>
+                    <li><a href="<?php echo BASE_URL; ?>index.php?route=dev" <?php echo isset($_GET['route']) && $_GET['route'] == 'dev' ? 'class="active"' : ''; ?>>Développement</a></li>
+                    <li><a href="<?php echo BASE_URL; ?>index.php?route=members" <?php echo isset($_GET['route']) && $_GET['route'] == 'members' ? 'class="active"' : ''; ?>>Membres</a></li>
                 </ul>
             </nav>
             <div class="user-actions">
@@ -62,28 +62,28 @@ global $api;
                             <i class="fas fa-chevron-down"></i>
                         </button>
                         <div class="user-dropdown-menu">
-                            <a href="profile.php?id=<?php echo $user['id']; ?>">
+                            <a href="<?php echo BASE_URL; ?>profile.php?id=<?php echo $user['id']; ?>">
                                 <i class="fas fa-user"></i> Mon Profil
                             </a>
-                            <a href="settings.php">
+                            <a href="<?php echo BASE_URL; ?>settings.php">
                                 <i class="fas fa-cog"></i> Paramètres
                             </a>
-                            <a href="new-article.php">
+                            <a href="<?php echo BASE_URL; ?>new-article.php">
                                 <i class="fas fa-pen"></i> Créer un Article
                             </a>
                             <?php if ($api->isModerator()): ?>
-                            <a href="index.php?route=admin">
+                            <a href="<?php echo BASE_URL; ?>index.php?route=admin">
                                 <i class="fas fa-tools"></i> Dashboard
                             </a>
                             <?php endif; ?>
-                            <a href="logout.php">
+                            <a href="<?php echo BASE_URL; ?>logout.php">
                                 <i class="fas fa-sign-out-alt"></i> Déconnexion
                             </a>
                         </div>
                     </div>
                 <?php else: ?>
-                    <a href="index.php?route=login" class="btn btn-outline">Connexion</a>
-                    <a href="index.php?route=register" class="btn btn-primary">Inscription</a>
+                    <a href="<?php echo BASE_URL; ?>index.php?route=login" class="btn btn-outline">Connexion</a>
+                    <a href="<?php echo BASE_URL; ?>index.php?route=register" class="btn btn-primary">Inscription</a>
                 <?php endif; ?>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- configure `BASE_URL` for installations in subdirectories
- use `BASE_URL` in header template so CSS/JS load correctly
- update admin breadcrumbs and about page logo to rely on `BASE_URL`

## Testing
- `php -l config.php`
- `php -l views/admin/articles.php`
- `php -l views/admin/categories.php`
- `php -l views/admin/dashboard.php`
- `php -l views/admin/threads.php`
- `php -l views/admin/users.php`
- `php -l views/templates/header.php`
- `php -l views/pages/about.php`
- `php tests/ArticleControllerTest.php` *(fails: PHPUnit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870a15b87c083329a5ce2ef31f0aeb7