### PR TITLE
Add random banner images when missing

### DIFF
--- a/config.php
+++ b/config.php
@@ -23,6 +23,10 @@ define('COLOR_ACCENT_RED', '#E6213A');
 // Default avatar image URL for users without a profile picture
 define('DEFAULT_AVATAR_URL', 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y');
 
+// Base URL for fetching random article banners
+define('RANDOM_BANNER_BASE', 'https://picsum.photos/seed/');
+define('RANDOM_BANNER_SIZE', '800/400');
+
 // Session timeout (in seconds)
 define('SESSION_TIMEOUT', 3600); // 1 hour
 

--- a/functions.php
+++ b/functions.php
@@ -203,6 +203,21 @@ function get_username(array $data) {
 }
 
 /**
+ * Retrieve the banner image URL for an article, generating a random one
+ * when none is provided.
+ *
+ * @param array $article Article data
+ * @return string URL of the banner image
+ */
+function get_article_banner_url(array $article) {
+    if (!empty($article['image_url'])) {
+        return $article['image_url'];
+    }
+    $seed = mt_rand(0, 1000000);
+    return RANDOM_BANNER_BASE . $seed . '/' . RANDOM_BANNER_SIZE;
+}
+
+/**
  * Filter an array of items to only keep published content when available.
  *
  * Items without an `is_pub` flag are left untouched.

--- a/views/article.php
+++ b/views/article.php
@@ -15,11 +15,9 @@
         <div class="grid grid-sidebar">
             <div>
                 <article class="article">
-            <?php if (isset($article['image_url']) && !empty($article['image_url'])): ?>
                 <div style="height: 400px; overflow: hidden;">
-                    <img src="<?php echo htmlspecialchars($article['image_url']); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>" style="width: 100%; height: 100%; object-fit: cover;">
+                    <img src="<?php echo htmlspecialchars(get_article_banner_url($article)); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>" style="width: 100%; height: 100%; object-fit: cover;">
                 </div>
-            <?php endif; ?>
             
             <div class="article-header">
                 

--- a/views/articles.php
+++ b/views/articles.php
@@ -40,10 +40,8 @@
                         <?php foreach ($articles_data as $article): ?>
                             <article class="article-card">
                                 <div class="article-card-image">
-                                    <?php if (isset($article['image_url']) && !empty($article['image_url'])): ?>
-                                        <img src="<?php echo htmlspecialchars($article['image_url']); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>">
-                                    <?php endif; ?>
-                                    <?php 
+                                    <img src="<?php echo htmlspecialchars(get_article_banner_url($article)); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>">
+                                    <?php
                                     $label_text = '';
                                     $label_color = '';
                                     

--- a/views/cyber_securite.php
+++ b/views/cyber_securite.php
@@ -72,9 +72,7 @@
                             <?php foreach ($security_articles as $article): ?>
                                 <article class="article-card">
                                     <div class="article-card-image">
-                                        <?php if (isset($article['image_url']) && !empty($article['image_url'])): ?>
-                                            <img src="<?php echo htmlspecialchars($article['image_url']); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>">
-                                        <?php endif; ?>
+                                        <img src="<?php echo htmlspecialchars(get_article_banner_url($article)); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>">
                                         <div class="article-card-label" style="background-color: var(--accent-red);">CYBERSÉCURITÉ</div>
                                     </div>
                                     <div class="article-card-content">

--- a/views/dev.php
+++ b/views/dev.php
@@ -77,9 +77,7 @@ console.table(users, ['name', 'role']);</code></pre>
                             <?php foreach ($dev_articles as $article): ?>
                                 <article class="article-card">
                                     <div class="article-card-image">
-                                        <?php if (isset($article['image_url']) && !empty($article['image_url'])): ?>
-                                            <img src="<?php echo htmlspecialchars($article['image_url']); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>">
-                                        <?php endif; ?>
+                                        <img src="<?php echo htmlspecialchars(get_article_banner_url($article)); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>">
                                         <div class="article-card-label" style="background-color: var(--purple);">DÉVELOPPEMENT</div>
                                     </div>
                                     <div class="article-card-content">

--- a/views/home.php
+++ b/views/home.php
@@ -119,9 +119,7 @@
                             <?php foreach ($latest_articles as $article): ?>
                                 <article class="article-card">
                                     <div class="article-card-image">
-                                        <?php if (isset($article['image_url']) && !empty($article['image_url'])): ?>
-                                            <img src="<?php echo htmlspecialchars($article['image_url']); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>">
-                                        <?php endif; ?>
+                                        <img src="<?php echo htmlspecialchars(get_article_banner_url($article)); ?>" alt="<?php echo htmlspecialchars($article['title']); ?>">
                                         <?php
                                         $label_text = '';
                                         $label_color = '';


### PR DESCRIPTION
## Summary
- add random banner configuration
- create helper to provide a fallback banner URL
- show article banners unconditionally with random fallback

## Testing
- `php -l config.php`
- `php -l functions.php`
- `php -l views/article.php`
- `php -l views/articles.php`
- `php -l views/cyber_securite.php`
- `php -l views/dev.php`
- `php -l views/home.php`
- `phpunit tests/ArticleControllerTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b0773b9c8332a3f4aad9a3366233