### PR TITLE
Fix thread filtering by category

### DIFF
--- a/views/forums.php
+++ b/views/forums.php
@@ -97,7 +97,13 @@
                                     // Get recent threads for this category
                                     $threads = [];
                                     try {
-                                        $threads = $api->request('/forum/threads?category_id=' . $category['id'] . '&limit=1&skip=0');
+                                        $threads = $api->request('/forum/threads?category_id=' . $category['id'] . '&limit=3&skip=0');
+                                        if (is_array($threads)) {
+                                            // Ensure threads actually belong to this category
+                                            $threads = array_values(array_filter($threads, function($t) use ($category) {
+                                                return isset($t['category_id']) && (int)$t['category_id'] === (int)$category['id'];
+                                            }));
+                                        }
                                     } catch (Exception $e) {
                                         // Silently fail if we can't get threads
                                     }

--- a/views/home.php
+++ b/views/home.php
@@ -60,7 +60,12 @@
                                         <?php
                                         $threads = [];
                                         try {
-                                            $threads = $this->api->request('/forum/threads?category_id=' . $category['id'] . '&limit=2&skip=0');
+                                            $threads = $this->api->request('/forum/threads?category_id=' . $category['id'] . '&limit=3&skip=0');
+                                            if (is_array($threads)) {
+                                                $threads = array_values(array_filter($threads, function($t) use ($category) {
+                                                    return isset($t['category_id']) && (int)$t['category_id'] === (int)$category['id'];
+                                                }));
+                                            }
                                         } catch (Exception $e) {
                                             // Silently fail if we can't get threads
                                         }


### PR DESCRIPTION
## Summary
- ensure latest threads on forums page are filtered by category and show 3 max
- update home page to display up to 3 threads per category

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6870b1359d24833299244df7ca1ec57b